### PR TITLE
Fix looking up the correct image to push to dockerhub

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -45,5 +45,5 @@ deployment:
     commands:
       - "[ ! -z $DOCKERHUB_REPO ]"
       - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
-      - "docker tag lando-api:build ${DOCKERHUB_REPO}:lando-api-${CIRCLE_SHA1}"
-      - "docker push ${DOCKERHUB_REPO}:lando-api-${CIRCLE_SHA1}"
+      - "docker tag ${DOCKERHUB_REPO} ${DOCKERHUB_REPO}:${CIRCLE_SHA1}"
+      - "docker push ${DOCKERHUB_REPO}:${CIRCLE_SHA1}"


### PR DESCRIPTION
The way we were looking for the image tag to push to dockerhub was an artifact of how were were pushing to dockerhub in our old conduit repo. The correct way is demonstrated in this commit, which smacleod has recommend and is consistent with how it is done in the [mozphab repo](https://github.com/mozilla-services/mozphab/blob/master/circle.yml#L40).

When this PR is merged it should correctly push to our DockerHub repo here [https://hub.docker.com/r/mozilla/lando-api/](https://hub.docker.com/r/mozilla/lando-api/).

This has been fixed in the lando-ui repo by [PR#3 there](https://github.com/mozilla-conduit/lando-ui/pull/3)