### PR TITLE
 🐛 Fix typo in revisions api: date_modifed (sic)

### DIFF
--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -93,7 +93,7 @@ def _format_revision(
         'phid': revision['phid'],
         'url': revision['uri'],
         'date_created': int(revision['dateCreated']),
-        'date_modifed': int(revision['dateModified']),
+        'date_modified': int(revision['dateModified']),
         'status': int(revision['status']),
         'status_name': revision['statusName'],
         'summary': revision['summary'],

--- a/tests/canned_responses/lando_api/revisions.py
+++ b/tests/canned_responses/lando_api/revisions.py
@@ -12,7 +12,7 @@ CANNED_LANDO_REVISION_1 = {
         "username": "imadueme_admin"
     },
     "date_created": 1495638270,
-    "date_modifed": 1496239141,
+    "date_modified": 1496239141,
     "id": 1,
     "parent_revisions": [],
     "phid": "PHID-DREV-1",
@@ -39,7 +39,7 @@ CANNED_LANDO_REVISION_2 = {
         "username": "imadueme_admin"
     },
     "date_created": 1495638280,
-    "date_modifed": 1496239151,
+    "date_modified": 1496239151,
     "id": 2,
     "parent_revisions": [
         CANNED_LANDO_REVISION_1


### PR DESCRIPTION
I discovered this typo while using the API to develop Lando UI. Thought I might as well fix it right away instead of writing code that depends on a typo.
