### PR TITLE
Use default phabricator api key to query public revisions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - PORT=80
       - VERSION_PATH=/version.json
       - PHABRICATOR_URL=https://mozphab.dev.mozaws.net
+      - PHABRICATOR_UNPRIVILEGED_API_KEY=api-123456789
   py3-linter:
     build:
       context: ./

--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -9,7 +9,7 @@ from connexion import problem
 from landoapi.phabricator_client import PhabricatorClient
 
 
-def get(api_key, revision_id):
+def get(revision_id, api_key=None):
     """ API endpoint at /revisions/{id} to get revision data. """
     phab = PhabricatorClient(api_key)
     revision = phab.get_revision(id=revision_id)

--- a/landoapi/phabricator_client.py
+++ b/landoapi/phabricator_client.py
@@ -18,7 +18,10 @@ class PhabricatorClient:
 
     def __init__(self, api_key):
         self.api_url = os.getenv('PHABRICATOR_URL') + '/api'
-        self.api_key = api_key
+        if api_key:
+            self.api_key = api_key
+        else:
+            self.api_key = os.getenv('PHABRICATOR_UNPRIVILEGED_API_KEY')
 
     def get_revision(self, id=None, phid=None):
         """ Gets a revision as defined by the Phabricator API.

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -33,8 +33,10 @@ paths:
           in: query
           type: string
           description: |
-            A Phabricator Conduit API key to use to get the revision.
-          required: true
+            A Phabricator Conduit API key to use to get the revision. If not
+            provided, then a default api key capable of getting public revisions
+            only will be used instead.
+          required: false
       responses:
         200:
           description: OK


### PR DESCRIPTION
After a long talk with our security folks, we came to a conclusion that having every user of Lando (1000+) enter their Phabricator API keys would be a possible security risk, even if stored in a secure cookie.

This patch allows Lando to use 1 key that it owns itself to query for public revisions on behalf of users. If the user does provide an api key, that key will be used instead, which allows users who have access to secure revisions to only input their API key when needed.