### PR TITLE
Include revision title in output of GET /revision/{id}

### DIFF
--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -91,6 +91,7 @@ def _format_revision(
     return {
         'id': int(revision['id']),
         'phid': revision['phid'],
+        'title': revision['title'],
         'url': revision['uri'],
         'date_created': int(revision['dateCreated']),
         'date_modified': int(revision['dateModified']),

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -64,6 +64,10 @@ definitions:
         type: string
         description: |
           The phid of the revision.
+      title:
+        type: string
+        description: |
+          The title of the revision.
       url:
         type: string
         description: |

--- a/tests/canned_responses/lando_api/revisions.py
+++ b/tests/canned_responses/lando_api/revisions.py
@@ -24,6 +24,7 @@ CANNED_LANDO_REVISION_1 = {
     },
     "status": 1,
     "status_name": "Needs Revision",
+    "title": "My test diff 1",
     "summary": "Summary 1",
     "test_plan": "Test Plan 1",
     "url": "https://mozphab.dev.mozaws.net/D1"
@@ -53,6 +54,7 @@ CANNED_LANDO_REVISION_2 = {
     },
     "status": 1,
     "status_name": "Needs Revision",
+    "title": "My test diff 2",
     "summary": "Summary 2",
     "test_plan": "Test Plan 2",
     "url": "https://mozphab.dev.mozaws.net/D2"


### PR DESCRIPTION
The title of a revision is very important, but, accidentally I left it out when I initially created the revision api.