### PR TITLE
Include bug id in /revisions/{id} API response

### DIFF
--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -110,9 +110,16 @@ def _format_revision(
                     _format_revision(phab, parent_revision_data, True)
                 )
 
+    bug_id = revision['auxiliary'].get('bugzilla.bug-id', None)
+    try:
+        bug_id = int(bug_id)
+    except (TypeError, ValueError):
+        bug_id = None
+
     return {
         'id': int(revision['id']),
         'phid': revision['phid'],
+        'bug_id': bug_id,
         'title': revision['title'],
         'url': revision['uri'],
         'date_created': int(revision['dateCreated']),

--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -86,16 +86,19 @@ def _format_revision(
         }
 
     # Load the repo if it isn't the same as the child revision's repo.
-    if last_repo and revision['repositoryPHID'] == last_repo['phid']:
-        repo = last_repo
+    if revision['repositoryPHID']:
+        if last_repo and revision['repositoryPHID'] == last_repo['phid']:
+            repo = last_repo
+        else:
+            raw_repo = phab.get_repo(revision['repositoryPHID'])
+            repo = {
+                'phid': raw_repo['phid'],
+                'short_name': raw_repo['name'],
+                'full_name': raw_repo['fullName'],
+                'url': raw_repo['uri'],
+            }
     else:
-        raw_repo = phab.get_repo(revision['repositoryPHID'])
-        repo = {
-            'phid': raw_repo['phid'],
-            'short_name': raw_repo['name'],
-            'full_name': raw_repo['fullName'],
-            'url': raw_repo['uri'],
-        }
+        repo = None
 
     # This recursively loads the parent of a revision, and the parents of
     # that parent, and so on, ultimately creating a linked-list type structure

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -103,6 +103,11 @@ definitions:
         type: string
         description: |
           The phid of the revision.
+      bug_id:
+        type: integer
+        description: |
+          The ID of the Bugzilla bug this revision belongs to. Or null if
+          it is not attached to a specific bug.
       title:
         type: string
         description: |

--- a/tests/canned_responses/lando_api/revisions.py
+++ b/tests/canned_responses/lando_api/revisions.py
@@ -15,6 +15,7 @@ CANNED_LANDO_REVISION_1 = {
     "date_modified": 1496239141,
     "id": 1,
     "parent_revisions": [],
+    "bug_id": 1,
     "phid": "PHID-DREV-1",
     "repo": {
         "full_name": "rMOZILLACENTRAL mozilla-central",
@@ -41,6 +42,7 @@ CANNED_LANDO_REVISION_2 = {
     },
     "date_created": 1495638280,
     "date_modified": 1496239151,
+    "bug_id": 1,
     "id": 2,
     "parent_revisions": [
         CANNED_LANDO_REVISION_1

--- a/tests/canned_responses/phabricator/revisions.py
+++ b/tests/canned_responses/phabricator/revisions.py
@@ -29,6 +29,7 @@ CANNED_REVISION_1 = {
             "ccs": [],
             "hashes": [],
             "auxiliary": {
+                "bugzilla.bug-id": "1",
                 "phabricator:projects": [],
                 "phabricator:depends-on": []
             },
@@ -67,6 +68,7 @@ CANNED_REVISION_2 = {
             "ccs": [],
             "hashes": [],
             "auxiliary": {
+                "bugzilla.bug-id": "1",
                 "phabricator:projects": [],
                 "phabricator:depends-on": ["PHID-DREV-1"]
             },


### PR DESCRIPTION
Our phabricator extensions inject the bugzilla bug id on the revisions retrieved via the api. It makes sense to pass this along through Lando API.

Also: prevent crash when Phabricator revision has no repository. Apparently, Phabricator revisions can be tied to no repository. This commit makes sure that we take that into account.