### PR TITLE
Send Mercurial patches to the transplant client for landing

### DIFF
--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -6,6 +6,8 @@ Revision API
 See the OpenAPI Specification for this API in the spec/swagger.yml file.
 """
 from connexion import problem
+
+from landoapi.hgexportbuilder import build_patch_for_revision
 from landoapi.phabricator_client import PhabricatorClient
 
 

--- a/landoapi/hgexportbuilder.py
+++ b/landoapi/hgexportbuilder.py
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Module for constructing Mercurial patches in 'hg export' format.
+"""
+
+HG_EXPORT_PATCH_TEMPLATE = """# HG changeset patch
+# User {author}
+# Date {patchdate}
+{commitdesc}
+
+{diff}"""
+
+
+def build_patch_for_revision(git_patch, author_data, revision_data):
+    """Generate a 'hg export' patch using Phabricator Revision data.
+
+    Args:
+        git_patch: A string holding a Git-formatted patch.
+        author_data: A Phabricator User data dictionary for the patch's author.
+        revision_data: A dictionary holding data fetched from a Phabricator
+            revision.
+
+    Returns:
+        A string containing a patch in 'hg export' format.
+    """
+    # FIXME: This needs to use the correct email.
+    # FIXME: in order: secondary phab user email, primary phab user email
+    # Author has to be the LDAP username of the patch author.
+    author = author_data['userName']
+
+    # Back-date the patch to the last modification date of the Revision it's
+    # based on.
+    #
+    # Assume Phabricator is returning valid date responses as "seconds since
+    # the Unix Epoch", but cast it to int() just to be sure.  Also assume the
+    #  Phabricator server is returning that number relative to UTC.
+    patchdate = '%s +0000' % int(revision_data['dateModified'])
+
+    return HG_EXPORT_PATCH_TEMPLATE.format(
+        author=author,
+        patchdate=patchdate,
+        commitdesc=revision_data['summary'],
+        diff=git_patch,
+    )

--- a/landoapi/transplant_client.py
+++ b/landoapi/transplant_client.py
@@ -14,7 +14,7 @@ class TransplantClient:
         self.api_url = os.getenv('TRANSPLANT_URL')
 
     @requests_mock.mock()
-    def land(self, ldap_username, tree, request):
+    def land(self, ldap_username, hgpatch, tree, request):
         """ Sends a push request to Transplant API to land a revision.
 
         Returns request_id received from Transplant API.
@@ -32,6 +32,7 @@ class TransplantClient:
                 'ldap_username': ldap_username,
                 'tree': tree,
                 'rev': 'rev',
+                'patch': hgpatch,
                 'destination': 'destination',
                 'push_bookmark': 'push_bookmark',
                 'commit_descriptions': 'commit_descriptions',

--- a/tests/test_hg_patch_builder.py
+++ b/tests/test_hg_patch_builder.py
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from landoapi.hgexportbuilder import build_patch_for_revision
+from landoapi.phabricator_client import PhabricatorClient
+
+git_diff_from_revision = """diff --git a/hello.c b/hello.c
+--- a/hello.c   Fri Aug 26 01:21:28 2005 -0700
++++ b/hello.c   Mon May 05 01:20:46 2008 +0200
+@@ -12,5 +12,6 @@
+ int main(int argc, char **argv)
+ {
+        printf("hello, world!\n");
++       printf("sure am glad I'm using Mercurial!\n");
+        return 0;
+ }
+"""
+
+hg_patch = """# HG changeset patch
+# User mpm_at_selenic
+# Date 1496239141 +0000
+Express great joy at existence of Mercurial
+
+diff --git a/hello.c b/hello.c
+--- a/hello.c   Fri Aug 26 01:21:28 2005 -0700
++++ b/hello.c   Mon May 05 01:20:46 2008 +0200
+@@ -12,5 +12,6 @@
+ int main(int argc, char **argv)
+ {
+        printf("hello, world!\n");
++       printf("sure am glad I'm using Mercurial!\n");
+        return 0;
+ }
+"""
+
+
+def test_build_patch(phabfactory, docker_env_vars):
+    phabfactory.user(username='mpm_at_selenic', phid='PHID-USER-mpm')
+    phabfactory.revision(id='D5', author_phid='PHID-USER-mpm')
+
+    phab = PhabricatorClient(api_key='api-key')
+    revision = phab.get_revision(id='D5')
+    revision['summary'] = "Express great joy at existence of Mercurial"
+    author = phab.get_revision_author(revision)
+
+    patch = build_patch_for_revision(git_diff_from_revision, author, revision)
+
+    assert patch == hg_patch

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -2,12 +2,16 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
+from unittest.mock import MagicMock
+
 import pytest
 
+from landoapi.hgexportbuilder import build_patch_for_revision
 from landoapi.models.storage import db as _db
 from landoapi.models.landing import (Landing, TRANSPLANT_JOB_STARTED)
+from landoapi.phabricator_client import PhabricatorClient
+from landoapi.transplant_client import TransplantClient
 
-from tests.canned_responses.phabricator.revisions import *
 from tests.canned_responses.lando_api.revisions import *
 from tests.canned_responses.lando_api.landings import *
 
@@ -24,7 +28,7 @@ def db(app):
         _db.drop_all()
 
 
-def test_landing_revision(db, client, phabfactory):
+def test_landing_revision_saves_data_in_db(db, client, phabfactory):
     phabfactory.user()
     phabfactory.revision()
     response = client.post(
@@ -46,6 +50,38 @@ def test_landing_revision(db, client, phabfactory):
         'revision_id': 'D1',
         'status': TRANSPLANT_JOB_STARTED
     }
+
+
+def test_landing_revision_calls_transplant_service(
+    db, client, phabfactory, monkeypatch
+):
+    # Mock the phabricator response data
+    phabfactory.user()
+    phabfactory.revision()
+
+    # Build the patch we expect to see
+    phabclient = PhabricatorClient('someapi')
+    revision = phabclient.get_revision('D1')
+    gitdiff = phabclient.get_latest_revision_diff_text(revision)
+    author = phabclient.get_revision_author(revision)
+    hgpatch = build_patch_for_revision(gitdiff, author, revision)
+
+    # The repo we expect to see
+    repo_uri = phabclient.get_revision_repo(revision)['uri']
+
+    tsclient = MagicMock(spec=TransplantClient)
+    monkeypatch.setattr('landoapi.models.landing.TransplantClient', tsclient)
+
+    client.post(
+        '/landings?api_key=api-key',
+        data=json.dumps({
+            'revision_id': 'D1'
+        }),
+        content_type='application/json'
+    )
+    tsclient().land.assert_called_once_with(
+        'ldap_username@example.com', hgpatch, repo_uri
+    )
 
 
 def test_get_transplant_status(db, client):


### PR DESCRIPTION
When requesting a landing, Construct 'hg export' formatted patches for
the Transplant service client to consume.

Todo
- [x] Construct the 'Date' patch header
- [x] Write tests for 'Date' header construction