### PR TITLE
Use uWSGI to serve the app in production

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -8,10 +8,26 @@ RUN apk --update --no-cache add \
 	sqlite
 RUN mkdir /db
 
-ADD requirements.txt /requirements.txt
-RUN pip install --no-cache -r /requirements.txt
-ADD dev-requirements.txt /dev-requirements.txt
-RUN pip install --no-cache -r /dev-requirements.txt
+COPY requirements.txt dev-requirements.txt /
+
+RUN set -ex \
+    && apk add --no-cache --virtual .build-deps \
+           gcc \
+           libc-dev \
+           musl-dev \
+           linux-headers \
+           pcre-dev \
+    && pip install --no-cache -r /requirements.txt \
+    && pip install --no-cache -r /dev-requirements.txt \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)" \
+	&& apk add --virtual .python-rundeps $runDeps \
+    && apk del .build-deps
 
 # Create a Dockerflow version file at the root so
 # we don't map over it below.

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -4,8 +4,30 @@
 
 FROM python:3.5-alpine
 
-RUN addgroup -g 1001 app && \
-    adduser -D -u 1001 -G app -s /usr/sbin/nologin app
+MAINTAINER mars@mozilla.com
+# These are unlikely to change from version to version of the container
+EXPOSE 9000
+CMD ["/usr/local/bin/uwsgi"]
+
+RUN addgroup -g 10001 app && adduser -D -u 10001 -G app -h /app app
+
+# uWSGI configuration
+ENV UWSGI_MODULE=landoapi.wsgi:app \
+	UWSGI_SOCKET=:9000 \
+	UWSGI_MASTER=1 \
+	UWSGI_WORKERS=2 \
+	UWSGI_THREADS=8 \
+    # Disable worker memory sharing optimizations.  They can cause memory leaks
+    # and issues with packages like Sentry.
+    # See https://discuss.newrelic.com/t/newrelic-agent-produces-system-error/43446
+	UWSGI_LAZY_APPS=1 \
+	UWSGI_WSGI_ENV_BEHAVIOR=holy \
+    # Make uWSGI die instead of reload when it gets SIGTERM (fixed in uWSGI 2.1)
+    UWSGI_DIE_ON_TERM=1 \
+    # Check that the options we gave uWSGI are sane
+    UWSGI_STRICT=1 \
+    # Die if the application threw an exception on startup
+    UWSGI_NEED_APP=1
 
 RUN apk --update --no-cache add \
 	sqlite
@@ -15,13 +37,32 @@ RUN chown app:app /db
 COPY migrations /migrations
 
 COPY requirements.txt /requirements.txt
-RUN pip install --no-cache -r /requirements.txt
+
+# Install pure-Python, compiled, and OS package dependencies.  Use scanelf to
+# uninstall any compile-time OS package dependencies and keep only the run-time
+# OS package dependencies.
+RUN set -ex \
+    && apk add --no-cache --virtual .build-deps \
+           gcc \
+           libc-dev \
+           musl-dev \
+           linux-headers \
+           pcre-dev \
+    && pip install --no-cache -r /requirements.txt \
+	&& runDeps="$( \
+		scanelf --needed --nobanner --recursive /usr/local \
+			| awk '{ gsub(/,/, "\nso:", $2); print "so:" $2 }' \
+			| sort -u \
+			| xargs -r apk info --installed \
+			| sort -u \
+	)" \
+	&& apk add --virtual .python-rundeps $runDeps \
+    && apk del .build-deps
 
 COPY . /app
 RUN pip install --no-cache /app
 
-# run as non priviledged user
+# Run as a non-privileged user
 USER app
 
-# TODO allow ops to use this as a wsgi app
 WORKDIR /app

--- a/landoapi/wsgi.py
+++ b/landoapi/wsgi.py
@@ -1,0 +1,11 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Construct an application instance that can be referenced by a WSGI server.
+"""
+import os
+
+from .app import create_app
+
+app = create_app(os.environ.get('VERSION_PATH', '/app/version.json'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,5 @@ python-dateutil==2.6.0 \
 Flask-Alembic==2.0.1 \
     --hash=sha256:05a1e6f4148dbfcc9280a393373bfbd250af6f9f4f0ca9f744ef8f7376a3deec \
     --hash=sha256:7e67740b0b08d58dcae0c701d56b56e60f5fa4af907bb82b4cb0469229ba94ff
+uWSGI==2.0.15 \
+    --hash=sha256:572ef9696b97595b4f44f6198fe8c06e6f4e6351d930d22e5330b071391272ff

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     ],
     keywords='mozilla commits development conduit',
     packages=find_packages(exclude=['docs', 'tests']),
+    package_data={'landoapi': ['spec/swagger.yml']},
     install_requires=[],
     extras_require={},
     entry_points={


### PR DESCRIPTION
Run the lando-api application under uWSGI.

To build and run the production image locally add the following to `docker-compose.override.yml`:

```yaml
version: '2'
services:
  lando-api:
    build:
      context: ./
      dockerfile: ./docker/Dockerfile-prod
    ports:
      - "9000:9000"
    environment:
      - UWSGI_WORKERS=1
      - UWSGI_SOCKET=:9001
      - UWSGI_HTTP=:9000
```
