### PR TITLE
Disable Alembic migrations during testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,21 @@ def versionfile(tmpdir):
 
 
 @pytest.fixture
-def app(versionfile, docker_env_vars):
+def disable_migrations(monkeypatch):
+    """Disable the Alembic DB migrations system in the app during testing."""
+
+    class StubAlembic:
+        def __init__(self):
+            pass
+
+        def init_app(self, app):
+            pass
+
+    monkeypatch.setattr('landoapi.app.alembic', StubAlembic())
+
+
+@pytest.fixture
+def app(versionfile, docker_env_vars, disable_migrations):
     """Needed for pytest-flask."""
     app = create_app(versionfile.strpath)
     return app.app


### PR DESCRIPTION
A side-effect of initializing the Alembic database schema migration
system is that it creates directories on the file system.  This
breaks the test suite in some environments and bloats test startup
time.  Since we don't need Alembic to run our acceptance tests, we
replace Alembic with a stub.