### PR TITLE
Fix Dockerfile-dev so it creates the lando-api-dev script

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -44,6 +44,6 @@ WORKDIR /app
 # We install outside of the app directory to create the .egg-info in a
 # location that will not be mounted over. This means /app needs to be
 # added to PYTHONPATH though.
-ENV PYTHONPATH /app
 RUN cd / && pip install --no-cache /app
+ENV PYTHONPATH /app
 CMD ["lando-api-dev"]


### PR DESCRIPTION
pip won't generate scripts listed in setup.py's entry_points if the
module is already available in the PYTHONPATH.  Scripts in the dev
environment, like lando-api-dev, are not being generated as a result.
Change when we set the PYTHONPATH environment variable in the dev
environment Dockerfile so pip will generate the scripts once
again.