### PR TITLE
Use unbuffered stdout for containers

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -46,4 +46,5 @@ WORKDIR /app
 # added to PYTHONPATH though.
 RUN cd / && pip install --no-cache /app
 ENV PYTHONPATH /app
+ENV PYTHONUNBUFFERED=1
 CMD ["lando-api-dev"]

--- a/docker/Dockerfile-prod
+++ b/docker/Dockerfile-prod
@@ -11,6 +11,8 @@ CMD ["/usr/local/bin/uwsgi"]
 
 RUN addgroup -g 10001 app && adduser -D -u 10001 -G app -h /app app
 
+ENV PYTHONUNBUFFERED=1
+
 # uWSGI configuration
 ENV UWSGI_MODULE=landoapi.wsgi:app \
 	UWSGI_SOCKET=:9000 \


### PR DESCRIPTION
Use unbuffered stdout for all containers.  In dev this makes print()
statements work.  In prod using unbuffered output for daemons is just
plain good practice.