### PR TITLE
Return HTTP 502 from failed phabricator heartbeat checks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import json
 
+import logging
 import pytest
 import requests_mock
 
@@ -57,7 +58,13 @@ def disable_migrations(monkeypatch):
 
 
 @pytest.fixture
-def app(versionfile, docker_env_vars, disable_migrations):
+def disable_log_output():
+    """Disable Python standard logging output to the console."""
+    logging.disable(logging.CRITICAL)
+
+
+@pytest.fixture
+def app(versionfile, docker_env_vars, disable_migrations, disable_log_output):
     """Needed for pytest-flask."""
     app = create_app(versionfile.strpath)
     return app.app

--- a/tests/test_dockerflow.py
+++ b/tests/test_dockerflow.py
@@ -3,6 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
+import requests
+
+import requests_mock
+
+from tests.canned_responses.phabricator.revisions import CANNED_EMPTY_RESULT
+from tests.utils import phab_url
 
 
 def test_dockerflow_lb_endpoint_returns_200(client):
@@ -18,3 +24,30 @@ def test_dockerflow_version_endpoint_response(client):
 def test_dockerflow_version_matches_disk_contents(client, versionfile):
     response = client.get('/__version__')
     assert response.json == json.load(versionfile.open())
+
+
+def test_heartbeat_returns_200_if_phabricator_api_is_up(client):
+    json_response = CANNED_EMPTY_RESULT.copy()
+    with requests_mock.mock() as m:
+        m.get(phab_url('conduit.ping'), status_code=200, json=json_response)
+
+        response = client.get('/__heartbeat__')
+
+        assert m.called
+        assert response.status_code == 200
+
+
+def test_heartbeat_returns_http_502_if_phabricator_ping_returns_error(client):
+    error_json = {
+        "result": None,
+        "error_code": "ERR-CONDUIT-CORE",
+        "error_info": "BOOM"
+    }
+
+    with requests_mock.mock() as m:
+        m.get(phab_url('conduit.ping'), status_code=500, json=error_json)
+
+        response = client.get('/__heartbeat__')
+
+        assert m.called
+        assert response.status_code == 502


### PR DESCRIPTION
To test this change, add the following to docker-compose.override.yml:

```yaml
version: '2'
services:
  lando-api:
    environment:
      - PHABRICATOR_URL=https://nosuchhost.test
```

and hit http://<yourdockerhostname>:8888/__heartbeat__.

The container log should output a WARNING level message.  It will not output INFO or DEBUG messages because we don't have the loggers configured for that yet (we should implement mozlogging instead).