### PR TITLE
Use mozlog for application logging

### DIFF
--- a/landoapi/dockerflow.py
+++ b/landoapi/dockerflow.py
@@ -31,12 +31,14 @@ def heartbeat():
     phab = PhabricatorClient(api_key='')
     try:
         phab.check_connection()
-    except PhabricatorAPIException as exc:
+    except PhabricatorAPIException:
         logger.warning(
-            'heartbeat: problem, Phabricator API connection', exc_info=exc
+            {
+                'msg': 'problem connecting to Phabricator',
+            }, 'heartbeat'
         )
         return 'heartbeat: problem', 502
-    logger.info('heartbeat: ok, all services are up')
+    logger.info({'msg': 'ok, all services are up'}, 'heartbeat')
     return 'heartbeat: ok', 200
 
 

--- a/landoapi/models/landing.py
+++ b/landoapi/models/landing.py
@@ -3,10 +3,14 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
 
+import logging
+
 from landoapi.hgexportbuilder import build_patch_for_revision
 from landoapi.models.storage import db
 from landoapi.phabricator_client import PhabricatorClient
 from landoapi.transplant_client import TransplantClient
+
+logger = logging.getLogger(__name__)
 
 TRANSPLANT_JOB_STARTING = 'pending'
 TRANSPLANT_JOB_STARTED = 'started'
@@ -71,6 +75,14 @@ class Landing(db.Model):
         landing.request_id = request_id
         landing.status = TRANSPLANT_JOB_STARTED
         landing.save()
+
+        logger.info(
+            {
+                'revision': revision_id,
+                'landing': landing.id,
+                'msg': 'landing created for revision'
+            }, 'landing.success'
+        )
 
         return landing
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -70,3 +70,6 @@ python-dateutil==2.6.0 \
 Flask-Alembic==2.0.1 \
     --hash=sha256:05a1e6f4148dbfcc9280a393373bfbd250af6f9f4f0ca9f744ef8f7376a3deec \
     --hash=sha256:7e67740b0b08d58dcae0c701d56b56e60f5fa4af907bb82b4cb0469229ba94ff
+mozlogging==0.1.0 \
+    --hash=sha256:2fc3d520a17b048c8723abdba19f6c01f2bcaf4182944aaac5906f28bd5b7d77 \
+    --hash=sha256:2e1362b80418b845164d8d47337da838dade05720dbaf17956d1cafebc511b94


### PR DESCRIPTION
Configure the application to use the mozlog structured log format for
 application-level log messages (log messages from libraries and
 frameworks still go through the Python Standard Library string logger).

To test, modify `docker-compose.override.yml` and set the `LOG_LEVEL` environment variable to the string value `debug`.  A message about logging initialization should appear in the container logs.  

Try setting the `LOG_LEVEL` value to `foobar` to see what happens if an unknown/typo'd log level is set.