### PR TITLE
Authenticate pingback source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - HOST_URL=https://lando-api.test
       - ENV=localdev
       - SENTRY_DSN=
+      - TRANSPLANT_API_KEY=set-api-key
+      - PINGBACK_ENABLED=y
     volumes:
       - ./:/app
       - ./.db/:/db/

--- a/landoapi/models/landing.py
+++ b/landoapi/models/landing.py
@@ -63,14 +63,18 @@ class Landing(db.Model):
         # save landing to make sure we've got the callback
         landing = cls(revision_id=revision_id, diff_id=diff_id).save()
 
-        trans = TransplantClient()
-        callback = '%s/landings/%s/update' % (
-            os.getenv('HOST_URL'), landing.id
+        # Define the pingback URL with the port
+        callback = '{host_url}:{pingback_port}/landings/{id}/update'.format(
+            host_url=os.getenv('HOST_URL'),
+            pingback_port=os.getenv('PINGBACK_PORT', 80),
+            id=landing.id
         )
+
+        trans = TransplantClient()
         # The LDAP username used here has to be the username of the patch
-        # pusher.
-        # FIXME: what value do we use here?
-        # FIXME: This client, or the person who pushed the 'Land it!' button?
+        # pusher (the person who pushed the 'Land it!' button).
+        # FIXME: change ldap_username@example.com to the real data retrieved
+        #        from Auth0 userinfo
         request_id = trans.land(
             'ldap_username@example.com', hgpatch, repo['uri'], callback
         )

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -139,6 +139,11 @@ paths:
         Sends request to transplant service and responds with just the
         status code
       parameters:
+        - name: API-Key
+          description: A Transplant API key
+          in: header
+          required: true
+          type: string
         - name: data
           in: body
           description: |
@@ -176,6 +181,11 @@ paths:
       responses:
         202:
           description: OK
+        403:
+          description: Service not authorized
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
         404:
           description: Landing does not exist
           schema:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv('TRANSPLANT_URL', 'http://autoland.test')
     monkeypatch.setenv('DATABASE_URL', 'sqlite://')
     monkeypatch.setenv('HOST_URL', 'http://lando-api.test')
+    monkeypatch.setenv('TRANSPLANT_API_KEY', 'someapikey')
+    monkeypatch.setenv('PINGBACK_ENABLED', 'y')
 
 
 @pytest.fixture


### PR DESCRIPTION
Uses API-Key header parameter to authenticate the request.
Adds TRANSPLANT_API_KEY environment variable to compare to the header.