### PR TITLE
Mock HOST_URL during test suite runs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv('PHABRICATOR_URL', 'http://phabricator.test')
     monkeypatch.setenv('TRANSPLANT_URL', 'http://autoland.test')
     monkeypatch.setenv('DATABASE_URL', 'sqlite://')
+    monkeypatch.setenv('HOST_URL', 'http://lando-api.test')
 
 
 @pytest.fixture


### PR DESCRIPTION
The test suite is broken outside the docker environment because it
depends on the HOST_URL environment variable.  Add a mock for the
variable so the suite passes again.