### PR TITLE
Use Sentry to report exceptions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - TRANSPLANT_URL=https://stub.transplant.example.com
       - DATABASE_URL=sqlite:////db/sqlite.db
       - HOST_URL=https://lando-api.test
+      - ENV=localdev
+      - SENTRY_DSN=
     volumes:
       - ./:/app
       - ./.db/:/db/

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -73,3 +73,11 @@ Flask-Alembic==2.0.1 \
 mozlogging==0.1.0 \
     --hash=sha256:2fc3d520a17b048c8723abdba19f6c01f2bcaf4182944aaac5906f28bd5b7d77 \
     --hash=sha256:2e1362b80418b845164d8d47337da838dade05720dbaf17956d1cafebc511b94
+raven[flask]==6.1.0 \
+    --hash=sha256:56dc9062dd42bca97350e5048ff417c914376366caa3b1b5f788b27ddc0a34b7 \
+    --hash=sha256:02cabffb173b99d860a95d4908e8b1864aad1b8452146e13fd7e212aa576a884
+contextlib2==0.5.5 \
+    --hash=sha256:f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00 \
+    --hash=sha256:509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48
+blinker==1.4 \
+    --hash=sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6


### PR DESCRIPTION
Does what is says on the tin.  Sentry is shut off for local development.  To use it you have to give Sentry a real DSN.

I have tested this change using the lando-api Sentry project.  It reports errors correctly when they occur in a local development container.  I think we can ship this.