### PR TITLE
Fix masked sentry variable

### DIFF
--- a/landoapi/app.py
+++ b/landoapi/app.py
@@ -17,8 +17,6 @@ from mozlogging import MozLogFormatter
 
 logger = logging.getLogger(__name__)
 
-sentry = Sentry()
-
 
 def create_app(version_path):
     """Construct an application instance."""


### PR DESCRIPTION
Remove a stale instance of the `Sentry()` object.  `initialize_sentry()` creates a local `Sentry()` instance that should be used instead of the instance removed by this PR.