### PR TITLE
Remove mocked transplant service

### DIFF
--- a/landoapi/transplant_client.py
+++ b/landoapi/transplant_client.py
@@ -6,9 +6,9 @@ import os
 
 import logging
 import requests
-import requests_mock
 
 from sqlalchemy import text
+
 from landoapi.models.storage import db
 
 logger = logging.getLogger(__name__)
@@ -20,8 +20,7 @@ class TransplantClient:
     def __init__(self):
         self.api_url = os.getenv('TRANSPLANT_URL')
 
-    @requests_mock.mock()
-    def land(self, ldap_username, hgpatch, tree, pingback, request):
+    def land(self, ldap_username, hgpatch, tree, pingback):
         """ Sends a push request to Transplant API to land a revision.
 
         Returns request_id received from Transplant API.
@@ -30,13 +29,6 @@ class TransplantClient:
         sql = text('SELECT COUNT(*) FROM landings')
         result = db.session.execute(sql).fetchone()
         request_id = result[0]
-
-        # Connect to stubbed Transplant service
-        request.post(
-            self.api_url + '/autoland',
-            json={'request_id': request_id},
-            status_code=200
-        )
 
         # API structure from VCT/testing/autoland_mach_commands.py
         result = self._POST(
@@ -75,6 +67,7 @@ class TransplantClient:
 
     def _request(self, url, data=None, params=None, method='GET'):
         data = data if data else {}
+
         response = requests.request(
             method=method,
             url=self.api_url + url,

--- a/tests/canned_responses/lando_api/landings.py
+++ b/tests/canned_responses/lando_api/landings.py
@@ -43,9 +43,9 @@ CANNED_LANDING_1 = {
 CANNED_LANDING_FACTORY_1 = {
     'id': 1,
     'status': 'started',
-    'request_id': 1,
+    'request_id': 3,
     'revision_id': 'D1',
-    'diff_id': 1,
+    'diff_id': 2,
     'error_msg': '',
     'result': None,
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 import requests_mock
 
 from landoapi.app import create_app
-from tests.factories import PhabResponseFactory
+from tests.factories import PhabResponseFactory, TransResponseFactory
 
 
 @pytest.fixture
@@ -23,10 +23,22 @@ def docker_env_vars(monkeypatch):
 
 
 @pytest.fixture
-def phabfactory():
-    """Mock the Phabricator service and build fake response objects."""
+def request_mocker():
+    """Yield a requests Mocker for response factories."""
     with requests_mock.mock() as m:
-        yield PhabResponseFactory(m)
+        yield m
+
+
+@pytest.fixture
+def phabfactory(request_mocker):
+    """Mock the Phabricator service and build fake response objects."""
+    yield PhabResponseFactory(request_mocker)
+
+
+@pytest.fixture
+def transfactory(request_mocker):
+    """Mock Transplant service."""
+    yield TransResponseFactory(request_mocker)
 
 
 @pytest.fixture

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,7 +16,7 @@ from tests.canned_responses.phabricator.repos import CANNED_REPO_MOZCENTRAL
 from tests.canned_responses.phabricator.revisions import CANNED_REVISION_1
 from tests.canned_responses.phabricator.users import CANNED_USER_1
 from tests.utils import phab_url, first_result_in_response, phid_for_response, \
-    form_matcher
+    form_matcher, trans_url
 
 
 class PhabResponseFactory:
@@ -242,3 +242,22 @@ class PhabResponseFactory:
             response['result'][str(new_value)] = response['result'][old_value]
             del response['result'][old_value]
         return response
+
+
+class TransResponseFactory:
+    """Mock Transplant service responses."""
+
+    def __init__(self, requestmocker):
+        """
+        Args:
+            requestmocker: A requests Mocker object.
+        """
+        self.mock = requestmocker
+
+    def create_autoland_response(self, request_id=1):
+        """Add response to autoland endpoint."""
+        self.mock.post(
+            trans_url('autoland'),
+            json={'request_id': request_id},
+            status_code=200
+        )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,6 +11,11 @@ def phab_url(path):
     return '%s/api/%s' % (os.getenv('PHABRICATOR_URL'), path)
 
 
+def trans_url(path):
+    """ Utility to generate a url to Transplant's API """
+    return '%s/%s' % (os.getenv('TRANSPLANT_URL'), path)
+
+
 def first_result_in_response(response_json):
     """Unpack a Phabricator response JSON's first result.
 


### PR DESCRIPTION
Transplant service is running via requests_mock.
This commit is removing this dependency so Lando API will be contacting
a real Transplant service.