### PR TITLE
Add diff and commit author information in GET /revisions/{id}

### DIFF
--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -256,11 +256,6 @@ definitions:
         type: string
         description: |
           The phid of the revision.
-      diff_id:
-        type: integer
-        description: |
-          most recent diff id as retrieved from the 'active diff' field from 
-          Phabricator
       bug_id:
         type: integer
         description: |
@@ -303,6 +298,10 @@ definitions:
         type: string
         description: |
           The test plan provided on the revision.
+      diff:
+        $ref: '#/definitions/Diff'
+        description: |
+          The most recent diff for the revision.
       author:
         $ref: '#/definitions/User'
       repo:
@@ -359,6 +358,42 @@ definitions:
         type: string
         description: |
           A url pointing to the repo on Phabricator.
+  Diff:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: |
+          The integer id of the Diff.
+      revision_id:
+        type: integer
+        description: |
+          The integer id of the Revision that this Diff belongs to.
+      date_created:
+        type: integer
+        description: |
+          The date this Diff was created as a unix timestamp.
+      date_modified:
+        type: integer
+        description: |
+          The date this Diff was last modified as a unix timestamp.
+      vcs_base_revision:
+        type: string
+        description: |
+          The commit hash id of the commit that this Diff was based on. I.e.
+          the parent commit of the commits used to make this Diff.
+      authors:
+        type: array
+        description: |
+          An array of the authors for each commit that was used in creating
+          this diff, sorted by tip commit first.
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            email:
+              type: string
   # RFS7807 Problem Details for HTTP APIs (https://tools.ietf.org/html/rfc7807)
   # is used for error messages. Extensions to the error can be speced using an
   # "allOf" schema keyword along with additional schema definition

--- a/tests/canned_responses/lando_api/revisions.py
+++ b/tests/canned_responses/lando_api/revisions.py
@@ -4,36 +4,29 @@
 # yapf: disable
 
 CANNED_LANDO_REVISION_1 = {
-    "author": {
-        "image_url": "https://d2kb8dptaglwte.cloudfront.net/file/data/oywgsrq6rtv5rdfbjvdv/PHID-FILE-632bsum6ksnpu77kymbq/alphanumeric_lato-dark_I.png-_5e622c-255%2C255%2C255%2C0.4.png",
-        "phid": "PHID-USER-imaduemeadmin",
-        "real_name": "Israel Madueme",
-        "url": "http://phabricator.test/p/imadueme_admin/",
-        "username": "imadueme_admin"
-    },
+    "status": 1,
+    "status_name": "Needs Revision",
+    "title": "My test diff 1",
+    "summary": "Summary 1",
+    "test_plan": "Test Plan 1",
+    "url": "http://phabricator.test/D1",
     "date_created": 1495638270,
     "date_modified": 1496239141,
     "id": 1,
     "parent_revisions": [],
     "bug_id": 1,
     "phid": "PHID-DREV-1",
-    "diff_id": 1,
-    "repo": {
-        "full_name": "rMOZILLACENTRAL mozilla-central",
-        "phid": "PHID-REPO-mozillacentral",
-        "short_name": "rMOZILLACENTRAL",
-        "url": "http://phabricator.test/source/mozilla-central/"
+    "diff": {
+        "date_created": 1496175380,
+        "date_modified": 1496175382,
+        "id": 1,
+        "revision_id": 1,
+        "vcs_base_revision": "39d5cc0fda5e16c49a59d29d4ca186a5534cc88b",
+        "authors": [
+            {"email": "mcote@mozilla.example", "name": "Mark Cote"},
+            {"email": "glob@mozilla.example", "name": "Byron Jones"}
+        ],
     },
-    "status": 1,
-    "status_name": "Needs Revision",
-    "title": "My test diff 1",
-    "summary": "Summary 1",
-    "test_plan": "Test Plan 1",
-    "url": "http://phabricator.test/D1"
-}
-
-
-CANNED_LANDO_REVISION_2 = {
     "author": {
         "image_url": "https://d2kb8dptaglwte.cloudfront.net/file/data/oywgsrq6rtv5rdfbjvdv/PHID-FILE-632bsum6ksnpu77kymbq/alphanumeric_lato-dark_I.png-_5e622c-255%2C255%2C255%2C0.4.png",
         "phid": "PHID-USER-imaduemeadmin",
@@ -41,15 +34,42 @@ CANNED_LANDO_REVISION_2 = {
         "url": "http://phabricator.test/p/imadueme_admin/",
         "username": "imadueme_admin"
     },
+    "repo": {
+        "full_name": "rMOZILLACENTRAL mozilla-central",
+        "phid": "PHID-REPO-mozillacentral",
+        "short_name": "rMOZILLACENTRAL",
+        "url": "http://phabricator.test/source/mozilla-central/"
+    },
+}
+
+
+CANNED_LANDO_REVISION_2 = {
     "date_created": 1495638280,
     "date_modified": 1496239151,
     "bug_id": 1,
     "id": 2,
     "parent_revisions": [
-        CANNED_LANDO_REVISION_1
+        dict(CANNED_LANDO_REVISION_1, diff=None)
     ],
     "phid": "PHID-DREV-2",
-    "diff_id": 1,
+    "diff": {
+        "date_created": 1496175380,
+        "date_modified": 1496175382,
+        "id": 1,
+        "revision_id": 1,
+        "vcs_base_revision": "39d5cc0fda5e16c49a59d29d4ca186a5534cc88b",
+        "authors": [
+            {"email": "mcote@mozilla.example", "name": "Mark Cote"},
+            {"email": "glob@mozilla.example", "name": "Byron Jones"}
+        ],
+    },
+    "author": {
+        "image_url": "https://d2kb8dptaglwte.cloudfront.net/file/data/oywgsrq6rtv5rdfbjvdv/PHID-FILE-632bsum6ksnpu77kymbq/alphanumeric_lato-dark_I.png-_5e622c-255%2C255%2C255%2C0.4.png",
+        "phid": "PHID-USER-imaduemeadmin",
+        "real_name": "Israel Madueme",
+        "url": "http://phabricator.test/p/imadueme_admin/",
+        "username": "imadueme_admin"
+    },
     "repo": {
         "full_name": "rMOZILLACENTRAL mozilla-central",
         "phid": "PHID-REPO-mozillacentral",

--- a/tests/canned_responses/phabricator/diffs.py
+++ b/tests/canned_responses/phabricator/diffs.py
@@ -71,7 +71,22 @@ CANNED_DIFF_1 = {
                         ],
                         "summary": "Remove CLOBBER file.",
                         "message": "Remove CLOBBER file.\n\nMozReview-Commit-ID: 1Fys7LV1jIw",
-                        "authorEmail": "mcote@mozilla.com"
+                        "authorEmail": "mcote@mozilla.example"
+                    },
+                    "4e0642eb92ed75989c3e9e90b0c6b1e0498e7387": {
+                        "author": "Byron Jones",
+                        "time": 1498687122,
+                        "branch": "default",
+                        "tag": "",
+                        "commit": "4e0642eb92ed75989c3e9e90b0c6b1e0498e7387",
+                        "rev": "4e0642eb92ed75989c3e9e90b0c6b1e0498e7387",
+                        "local": "362117",
+                        "parents": [
+                            "39d5cc0fda5e16c49a59d29d4ca186a5534cc88b"
+                        ],
+                        "summary": "Bug 00000 - Get Sync engines and the Sync service working with promises/tasks. r?rnewman.",
+                        "message": "Bug 00000 - Get Sync engines and the Sync service working with promises/tasks. r?rnewman. Etc Etc",
+                        "authorEmail": "glob@mozilla.example"
                     }
                 }
             },


### PR DESCRIPTION
Clients sometimes need to know about the most recent diff for a revision. This change returns some metadata about the diff as well as the name and email address of the commit authors.

For example, lando-ui will use this information to allow the user to preview the final commit message allowing the user to make any final edits ahead of time.

https://trello.com/c/V3EMcEQC/445-2-return-commit-authors-in-revision-data