### PR TITLE
Change the environment variable name representing the pingback url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,11 @@ services:
       - PHABRICATOR_UNPRIVILEGED_API_KEY=api-123456789
       - TRANSPLANT_URL=https://stub.transplant.example.com
       - DATABASE_URL=sqlite:////db/sqlite.db
-      - HOST_URL=https://lando-api.test
       - ENV=localdev
       - SENTRY_DSN=
       - TRANSPLANT_API_KEY=set-api-key
       - PINGBACK_ENABLED=y
+      - PINGBACK_HOST_URL=https://lando-api.test
     volumes:
       - ./:/app
       - ./.db/:/db/

--- a/landoapi/models/landing.py
+++ b/landoapi/models/landing.py
@@ -64,10 +64,8 @@ class Landing(db.Model):
         landing = cls(revision_id=revision_id, diff_id=diff_id).save()
 
         # Define the pingback URL with the port
-        callback = '{host_url}:{pingback_port}/landings/{id}/update'.format(
-            host_url=os.getenv('HOST_URL'),
-            pingback_port=os.getenv('PINGBACK_PORT', 80),
-            id=landing.id
+        callback = '{host_url}/landings/{id}/update'.format(
+            host_url=os.getenv('PINGBACK_HOST_URL'), id=landing.id
         )
 
         trans = TransplantClient()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,9 +17,9 @@ def docker_env_vars(monkeypatch):
     monkeypatch.setenv('PHABRICATOR_URL', 'http://phabricator.test')
     monkeypatch.setenv('TRANSPLANT_URL', 'http://autoland.test')
     monkeypatch.setenv('DATABASE_URL', 'sqlite://')
-    monkeypatch.setenv('HOST_URL', 'http://lando-api.test')
     monkeypatch.setenv('TRANSPLANT_API_KEY', 'someapikey')
     monkeypatch.setenv('PINGBACK_ENABLED', 'y')
+    monkeypatch.setenv('PINGBACK_HOST_URL', 'http://lando-api.test')
 
 
 @pytest.fixture

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -95,7 +95,7 @@ def test_landing_revision_calls_transplant_service(
     )
     tsclient().land.assert_called_once_with(
         'ldap_username@example.com', hgpatch, repo_uri,
-        '{}:80/landings/1/update'.format(os.getenv('HOST_URL'))
+        '{}/landings/1/update'.format(os.getenv('PINGBACK_HOST_URL'))
     )
 
 


### PR DESCRIPTION
Currently the name of the variable is HOST_URL. This might be confused
with generic Lando API host url. The name is then changed to
PINGBACK_HOST_URL.
We also no longer need PINGBACK_PORT. It is removed.