### PR TITLE
dockerflow: set cache-control header in responses.

### DIFF
--- a/landoapi/dockerflow.py
+++ b/landoapi/dockerflow.py
@@ -9,7 +9,6 @@ specification.  See https://github.com/mozilla-services/Dockerflow for details.
 import json
 import logging
 
-import requests
 from flask import Blueprint, current_app, jsonify
 
 from landoapi.phabricator_client import PhabricatorClient, \
@@ -18,6 +17,15 @@ from landoapi.phabricator_client import PhabricatorClient, \
 logger = logging.getLogger(__name__)
 
 dockerflow = Blueprint('dockerflow', __name__)
+
+
+@dockerflow.after_request
+def disable_caching(response):
+    """Disable caching on a response and return it."""
+    response.cache_control.no_cache = True
+    response.cache_control.no_store = True
+    response.cache_control.must_revalidate = True
+    return response
 
 
 @dockerflow.route('/__heartbeat__')


### PR DESCRIPTION
The dockerflow health and version endpoints should instruct the caller
not to cache any results. This commit sets Cache-Control to properly
disable caching.

An unused requests import is also removed as cleanup.