### PR TITLE
circleci: remove unsupported '-e' argument to docker login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
       - deploy:
           command: |
             if [[ "x$DOCKERHUB_REPO" != x ]]; then
-              docker login -e "$DOCKER_EMAIL" -u "$DOCKER_USER" -p "$DOCKER_PASS"
+              docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
               docker tag "${DOCKERHUB_REPO}" "${DOCKERHUB_REPO}:${CIRCLE_SHA1}"
               docker push "${DOCKERHUB_REPO}:${CIRCLE_SHA1}"
               if [[ ${CIRCLE_BRANCH} == master ]]; then


### PR DESCRIPTION
Summary:
docker login used to support an -e ("email") option.
Since we're using a newer docker now, this is an error.

Tags: #secure-revision

Bug #: 1442013

Differential Revision: https://phabricator.services.mozilla.com/D4776