### PR TITLE
WIP api: report secure revisions (bug 1539289)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -165,7 +165,14 @@ def _assess_transplant_request(phab, landing_path):
         revision["phid"]: get_collated_reviewers(revision) for revision, _ in to_land
     }
 
+    secure_project_phid = get_secure_project_phid(phab)
+
+    assessment = TransplantAssessment()
+    revisions = [revision for revision, _ in to_land]
+    assessment.set_secure_revisions(revisions, secure_project_phid)
+
     assessment = check_landing_warnings(
+        assessment,
         g.auth0_user,
         to_land,
         repo,
@@ -173,7 +180,6 @@ def _assess_transplant_request(phab, landing_path):
         reviewers,
         users,
         projects,
-        get_secure_project_phid(phab),
     )
     return (assessment, to_land, landing_repo, stack_data)
 
@@ -184,7 +190,7 @@ def dryrun(data):
     phab = g.phabricator
     landing_path, _ = _unmarshal_transplant_request(data)
     assessment, *_ = _assess_transplant_request(phab, landing_path)
-    return assessment.to_dict()
+    return assessment.to_dict()  # FIXME how to validate output against swagger spec?
 
 
 @auth.require_auth0(scopes=("lando", "profile", "email"), userinfo=True)

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -539,6 +539,14 @@ definitions:
           warnings to the end user and have the user acknowledge the warnings
           with a checkbox. Once acknowledged, the UI can pass the confirmation
           token to the transplant endpoint so the transplant can proceed.
+      secureRevisions:
+        type: array
+        description: |
+          A list of Revisions that should follow the Security Bug Approval Process.
+        items:
+          type: string
+          description: |
+            A Phabricator revision PHID.
       blocker:
         type: string
         description: |


### PR DESCRIPTION
Return a list of secure revisions from API calls that produce a TransplantAssessment.