### PR TITLE
dev: pin the db container to postgres v9.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       - redis.queue
       - smtp
   lando-api.db:
-    image: postgres:alpine
+    image: postgres:9.6-alpine
     environment:
       - POSTGRES_PASSWORD=password
       - POSTGRES_USER=postgres


### PR DESCRIPTION
Pin the PostgreSQL container version to v9.6 in docker-compose.yml.  The
service dies with an error about incompatible init scripts if you try
to start the app or conduit suite with Postgres v11.