### PR TITLE
transplant: Increase read timeout for transplant request (Bug 1542247).

### DIFF
--- a/landoapi/transplant_client.py
+++ b/landoapi/transplant_client.py
@@ -141,7 +141,7 @@ class TransplantClient:
                 "pingback_url": pingback_url,
             },
             auth=(self.username, self.password),
-            timeout=10,
+            timeout=(10, 30),
         )
         response.raise_for_status()
 


### PR DESCRIPTION
We had a rare event where transplant was taking *just* over 10 seconds
to complete the request from Lando. This resulted in Lando throwing a
timeout even though transplant had properly queued the request. This
change increases the read timeout specifically to allow 30 seconds.
While this shouldn't be hit often, it will hopefully save us if this
happens again.