### PR TITLE
app: only wrap API exceptions in production environments

### DIFF
--- a/landoapi/hooks.py
+++ b/landoapi/hooks.py
@@ -85,6 +85,8 @@ def initialize_hooks(flask_app):
     flask_app.before_request(request_logging_before_request)
     flask_app.after_request(request_logging_after_request)
 
-    flask_app.register_error_handler(
-        PhabricatorAPIException, handle_phabricator_api_exception
-    )
+    # Only wrap/mask exceptions if we are in a production-like environment.
+    if not flask_app.propagate_exceptions:
+        flask_app.register_error_handler(
+            PhabricatorAPIException, handle_phabricator_api_exception
+        )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-from landoapi.hooks import initialize_hooks
 from landoapi.phabricator import (
     PhabricatorAPIException,
     PhabricatorCommunicationException,
@@ -36,7 +35,6 @@ def test_phabricator_api_exception_handled(app, client):
     # We need to tell Flask to handle exceptions as if it were in a production
     # environment.
     app.config["PROPAGATE_EXCEPTIONS"] = False
-    initialize_hooks(app)
 
     @app.route("/__testing__/phab_exception1")
     def phab_exception1():

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,7 +1,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
+from landoapi.hooks import initialize_hooks
 from landoapi.phabricator import (
     PhabricatorAPIException,
     PhabricatorCommunicationException,
@@ -33,6 +33,11 @@ def test_app_wide_headers_csp_report_uri(client, config):
 
 
 def test_phabricator_api_exception_handled(app, client):
+    # We need to tell Flask to handle exceptions as if it were in a production
+    # environment.
+    app.config["PROPAGATE_EXCEPTIONS"] = False
+    initialize_hooks(app)
+
     @app.route("/__testing__/phab_exception1")
     def phab_exception1():
         raise PhabricatorAPIException("OOPS!")


### PR DESCRIPTION
The default error handlers eat the PhabricatorAPIException root cause
and traceback. This makes debugging API failures difficult and breaks
PyCharm unittest integration.

We can make the error handler optional in the same way that the Flask
default error handler is optional: in production it wraps all errors,
but in the test and debug environments exceptions are allowed to
propagate through the stack to make debugging easier.