### PR TITLE
transplants: remove #check-in_needed when landing (Bug 1535157).

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - "8888:8888"
     environment:
       - PHABRICATOR_URL=https://phabricator-dev.allizom.org/
+      - PHABRICATOR_ADMIN_API_KEY=api-0123456789012345678901234567
       - PHABRICATOR_UNPRIVILEGED_API_KEY=api-0123456789012345678901234567
       - DATABASE_URL=postgresql://postgres:password@lando-api.db/lando_api_dev
       - ENV=localdev

--- a/landoapi/app.py
+++ b/landoapi/app.py
@@ -86,6 +86,7 @@ def load_config():
         ("OIDC_IDENTIFIER", None),
         ("PATCH_BUCKET_NAME", None),
         ("PINGBACK_ENABLED", "n"),
+        ("PHABRICATOR_ADMIN_API_KEY", None),
         ("PHABRICATOR_UNPRIVILEGED_API_KEY", None),
         ("PHABRICATOR_URL", None),
         ("SENTRY_DSN", None),

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 SEC_PROJ_SLUG = "secure-revision"
 SEC_PROJ_CACHE_KEY = "secure-project-phid"
 SEC_PROJ_CACHE_TIMEOUT = 86400  # 60s * 60m * 24h
+CHECKIN_PROJ_SLUG = "check-in_needed"
+CHECKIN_PROJ_CACHE_KEY = "checkin-project-phid"
+CHECKIN_PROJ_CACHE_TIMEOUT = 86400  # 60s * 60m * 24h
 
 
 def project_search(phabricator, project_phids):
@@ -51,6 +54,34 @@ def get_secure_project_phid(phabricator):
         logger.warning(
             "Could not find a phid for the secure project",
             extra=dict(slug=SEC_PROJ_SLUG),
+        )
+        return None
+
+    return phabricator.expect(project, "phid")
+
+
+@cache.cached(key_prefix=CHECKIN_PROJ_CACHE_KEY, timeout=CHECKIN_PROJ_CACHE_TIMEOUT)
+def get_checkin_project_phid(phabricator):
+    """Return a phid for the project indicating check-in is needed.
+
+    Args:
+        phabricator: A PhabricatorClient instance.
+
+    Returns:
+        A string phid if the project is found, otherwise None.
+    """
+    project = phabricator.single(
+        phabricator.call_conduit(
+            "project.search", constraints={"slugs": [CHECKIN_PROJ_SLUG]}
+        ),
+        "data",
+        none_when_empty=True,
+    )
+
+    if project is None:
+        logger.warning(
+            "Could not find a phid for the Check-in Needed project",
+            extra=dict(slug=CHECKIN_PROJ_SLUG),
         )
         return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from landoapi.app import construct_app, load_config, SUBSYSTEMS
 from landoapi.cache import cache, cache_subsystem
 from landoapi.mocks.auth import MockAuth0, TEST_JWKS
 from landoapi.phabricator import PhabricatorClient
-from landoapi.projects import SEC_PROJ_SLUG
+from landoapi.projects import CHECKIN_PROJ_SLUG, SEC_PROJ_SLUG
 from landoapi.repos import Repo, SCM_LEVEL_3
 from landoapi.storage import db as _db, db_subsystem
 from landoapi.tasks import celery
@@ -77,6 +77,7 @@ def docker_env_vars(versionfile, monkeypatch):
     )
     monkeypatch.setenv("LANDO_UI_URL", "http://lando-ui.test")
     monkeypatch.setenv("PHABRICATOR_URL", "http://phabricator.test")
+    monkeypatch.setenv("PHABRICATOR_ADMIN_API_KEY", "api-thiskeymustbe32characterslen")
     monkeypatch.setenv(
         "PHABRICATOR_UNPRIVILEGED_API_KEY", "api-thiskeymustbe32characterslen"
     )
@@ -117,6 +118,11 @@ def phabdouble(monkeypatch):
 @pytest.fixture
 def secure_project(phabdouble):
     return phabdouble.project(SEC_PROJ_SLUG)
+
+
+@pytest.fixture
+def checkin_project(phabdouble):
+    return phabdouble.project(CHECKIN_PROJ_SLUG)
 
 
 @pytest.fixture

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,31 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import pytest
+
+from landoapi.phabricator import (
+    PhabricatorAPIException,
+    PhabricatorCommunicationException,
+)
+from landoapi.tasks import admin_remove_phab_project
+
+
+def test_admin_remove_phab_project_succeeds(phabdouble, app):
+    p = phabdouble.project("test-project")
+    r = phabdouble.revision(projects=[p])
+    admin_remove_phab_project(r["phid"], p["phid"])
+
+
+def test_admin_remove_phab_project_throws_exception_for_missing_revision(
+    phabdouble, app
+):
+    p = phabdouble.project("test-project")
+    with pytest.raises(PhabricatorAPIException) as excinfo:
+        admin_remove_phab_project("PHID-DREV-NOTAREALPHID", p["phid"])
+
+    # Make sure that we haven't thrown a PhabricatorCommunicationException
+    # which would be a transient error. The exception should be a normal
+    # PhabricatorAPIException.
+    assert isinstance(excinfo.value, PhabricatorAPIException)
+    assert not isinstance(excinfo.value, PhabricatorCommunicationException)
+    assert "does not identify a valid object" in excinfo.value.error_info


### PR DESCRIPTION
Because Check-in Needed is being migrated to Phabricator and will be
handled by Lando, we now remove the tag from revisions when landing.
This is done asynchronously after triggering the landing so that any
errors will not block a proper response. It could have been done before
triggering the landing but any transient failure talking to transplant
would have prevented the landing even though the tag was removed.

Additionally Lando now has a `PHABRICATOR_ADMIN_API_KEY` environment
variable which is used to specify an API key for privileged actions.
This key must have access to all revisions, including those marked as
secure. Care should be taken when using this API key.

Removal of the #check-in_needed tag uses the admin api key to ensure
that it is successful for all revisions and that it is clear Lando is
the bot user causing the removal.

This change was tested by updating the automated tests, and running the
removal code manually against phabricator-dev.allizom.org.