### PR TITLE
tests: enable the TESTING config flag during test suite runs

### DIFF
--- a/landoapi/app.py
+++ b/landoapi/app.py
@@ -113,7 +113,7 @@ def load_config():
     return config
 
 
-def construct_app(config, testing=False):
+def construct_app(config):
     app = connexion.App(__name__, specification_dir="spec/")
 
     app.add_api(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,7 +166,10 @@ def disable_migrations(monkeypatch):
 def app(versionfile, docker_env_vars, disable_migrations, mocked_repo_config):
     """Needed for pytest-flask."""
     config = load_config()
-    app = construct_app(config, testing=True)
+    # We need the TESTING setting turned on to get tracebacks when testing API
+    # endpoints with the TestClient.
+    config["TESTING"] = True
+    app = construct_app(config)
     flask_app = app.app
     flask_app.test_client_class = JSONClient
     for system in SUBSYSTEMS:


### PR DESCRIPTION
Flask uses the TESTING config variable to determine if test suite errors
should propagate or be wrapped in generic HTTP status codes.  The
correct behaviour is to set TESTING=True during test suite runs.

 Also killed the dead 'testing' parameter to construct_app.