### PR TITLE
[sec-approval/3] client: wrap the transaction.search endpoint (bug 1553715)

### DIFF
--- a/landoapi/transactions.py
+++ b/landoapi/transactions.py
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Functions for working with Phabricator transactions."""
+from landoapi.phabricator import PhabricatorClient
+
+
+def transaction_search(phabricator, object_identifier, limit=100):
+    """Yield the Phabricator transactions related to an object.
+
+    See https://phabricator.services.mozilla.com/conduit/method/transaction.search/.
+
+    If the transaction list is larger that one page of API results then the generator
+    will call the Phabricator API successive times to fetch the full transaction list.
+
+    Args:
+        phabricator: A PhabricatorClient instance.
+        object_identifier: An object identifier (PHID or monogram) whose transactions
+            we want to fetch.
+        limit: Integer keyword, limit the number of records retrieved per API call.
+            Default is 100 records.
+
+    Returns:
+        Yields individual transactions.
+    """
+    next_page_start = None
+
+    while True:
+        transactions = phabricator.call_conduit(
+            "transaction.search",
+            objectIdentifier=object_identifier,
+            limit=limit,
+            after=next_page_start,
+        )
+
+        yield from PhabricatorClient.expect(transactions, "data")
+
+        next_page_start = transactions["cursor"]["after"]
+
+        if next_page_start is None:
+            # This was the last page of results.
+            return
+
+
+def get_raw_comments(transaction):
+    """Return a list of 'raw' comment bodies in a Phabricator transaction.
+
+    A single transaction can have multiple comment bodies: e.g. a top-level comment
+    and a couple of inline comments along with it.
+
+    See https://phabricator.services.mozilla.com/conduit/method/transaction.search/.
+    """
+    return [comment["content"]["raw"] for comment in transaction["comments"]]

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -147,17 +147,9 @@ class PhabricatorDouble:
             }
         )
 
-        next_free_txn_id = len(self._transactions)
-        for txn_id, comment in enumerate(comments, start=next_free_txn_id):
-            # See https://phabricator.services.mozilla.com/conduit/method/transaction.search/  # noqa
-            # for the Conduit API result object structure.
-            self._transactions.append(
-                {
-                    "id": txn_id,
-                    "type": "comment",
-                    "objectPHID": phid,
-                    "comments": [{"content": {"raw": comment}}],
-                }
+        for comment in comments:
+            self.transaction(
+                "comment", revision, comments=[{"content": {"raw": comment}}]
             )
 
         return revision
@@ -423,6 +415,67 @@ class PhabricatorDouble:
         )
 
         return project
+
+    def transaction(
+        self, transaction_type: str, object: dict, operations=None, comments=None
+    ):
+        """Return a Phabricator Transaction object.
+
+        Args:
+            transaction_type: String describing the transaction type.
+                e.g. "subscribers", "projects", "accept".
+            object: A dict structured as a Phabricator API object being modified by the
+                transaction. e.g. a revision dict or project dict.
+            operations: Optional list of operations that the transaction is performing.
+                Note that this argument's value and structure can change depending on
+                the value of the "type" argument.
+                e.g. When adding a subscriber to a revision the transaction type would
+                be "subscriber" and the operations argument would be
+                [{ "operation": "add", "phid": "PHID-USER-abc123"}]
+            comments: Optional list of comments modified by this transaction. Only
+                applies when the transaction type is "comment" or "inline". Structure
+                varies greatly depending on the comment type.
+
+        """
+        # Pull out what type of object we are operating on: DREV? PROJ?
+        object_type = object["type"]
+        object_phid = object["phid"]
+        comments = comments or []
+        fields = {}
+
+        if operations:
+            fields["operations"] = operations
+
+        phid = self._new_phid(f"XACT-{object_type}-")
+        transaction = {
+            "id": self._new_id(self._transactions),
+            "phid": phid,
+            "type": transaction_type,
+            # Not implemented.
+            "authorPHID": None,
+            "objectPHID": object_phid,
+            "dateCreated": 1559779750,
+            "dateModified": 1559779750,
+            # No idea what this field is for.
+            "groupID": "zmgrbvzbcclaubtg4yt2ihwwotxewc4h",
+            "comments": comments,
+            "fields": fields,
+        }
+        self._transactions.append(transaction)
+        self._phids.append(
+            {
+                "phid": phid,
+                # Unlike other objects transactions don't have a URI. This field
+                # is just the hostname with no path component.
+                "uri": "https://phabricator.services.mozilla.com",
+                "typeName": "Transaction",
+                "type": "XACT",
+                "name": "Unknown Object (Transaction)",
+                "fullName": "Unknown Object (Transaction)",
+                "status": "open",
+            }
+        )
+        return transaction
 
     @conduit_method("conduit.ping")
     def conduit_ping(self):
@@ -1063,18 +1116,38 @@ class PhabricatorDouble:
         after=None,
         limit=100,
     ):
-        matching_transactions = [
-            t for t in self._transactions if t["objectPHID"] == objectIdentifier
-        ]
-        # We don't want tests that work with our returned result to accidentally
-        # modify a transaction object.
-        matching_transactions = deepcopy(matching_transactions)
+        def to_response(i):
+            return deepcopy(
+                {
+                    "id": i["id"],
+                    "phid": i["phid"],
+                    "type": i["type"],
+                    "authorPHID": i["authorPHID"],
+                    "objectPHID": i["objectPHID"],
+                    "dateCreated": i["dateCreated"],
+                    "dateModified": i["dateModified"],
+                    "groupID": i["groupID"],
+                    "comments": i["comments"],
+                    "fields": i["fields"],
+                }
+            )
+
+        items = list(self._transactions)
+
+        if objectIdentifier:
+            items = [i for i in items if i["objectPHID"] == objectIdentifier]
+
+        if constraints and "phids" in constraints:
+            items = [i for i in items if i["phid"] in constraints["phids"]]
+
+        if constraints and "authorPHIDs" in constraints:
+            items = [i for i in items if i["authorPHIDs"] in constraints["authorPHIDs"]]
 
         if after is None:
             after = 0
 
         next_page_end = after + limit
-        page = matching_transactions[after:next_page_end]
+        page = items[after:next_page_end]
         # Set the 'after' cursor.
         if len(page) < limit:
             # This is the last page of results.
@@ -1084,7 +1157,7 @@ class PhabricatorDouble:
             after = next_page_end
 
         return {
-            "data": page,
+            "data": [to_response(i) for i in page],
             "cursor": {
                 "limit": limit,
                 "after": after,
@@ -1221,6 +1294,19 @@ class PhabricatorDouble:
         return {i["phid"]: deepcopy(i) for i in self._phids if i["phid"] in phids}
 
     def _new_phid(self, prefix):
+        """Generate a unique PHID of the given type, e.g. 'PHID-DREV-123'.
+
+        For example, given the prefix 'DREV-', the function will generate a
+        PHID of 'PHID-DREV-0'. Given the prefix of 'DIFF-' it will return
+        'PHID-DIFF-abc123'.
+
+        PHIDs are number starting at zero and proceed sequentially for each type. For
+        example, Revision PHIDs will be generated as 'PHID-DREV-0', 'PHID-DREV-1', ...
+
+        Args:
+            prefix: The string to be used as the PHID identifier. Should include the
+                dash between the type and object ID, e.g. 'DREV-' or 'PROJ-'.
+            """
         suffix = self._phid_counters.get(prefix, 0)
         self._phid_counters[prefix] = self._phid_counters.get(prefix, 0) + 1
         return "PHID-{}{}".format(prefix, suffix)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1117,6 +1117,16 @@ class PhabricatorDouble:
         limit=100,
     ):
         def to_response(i):
+            # Explicitly tell the developer using the mock that they need to check the
+            # type of transaction they are using and make sure it is serialized
+            # correctly by this function.
+            if i["type"] not in ("comment", "dummy"):
+                raise ValueError(
+                    "PhabricatorDouble transactions do not have support"
+                    'for the "{}" transaction type. '
+                    "If you have added use of a new transaction type please "
+                    "update PhabricatorDouble to support it.".format(i["type"])
+                )
             return deepcopy(
                 {
                     "id": i["id"],

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,37 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import string
+
+from landoapi.transactions import transaction_search, get_raw_comments
+
+
+def test_transaction_search(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    comments = ["yes!", "no?", "~wobble~"]
+    # Adding comments to a revision generates transactions and gives us a
+    # PHID to retrieve them.
+    revision = phabdouble.revision(comments=comments)
+    transactions = list(transaction_search(phab, revision["phid"]))
+    assert len(transactions) == len(comments)
+
+
+def test_no_transaction_search_results_returns_empty_list(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    # Adding comments to a revision generates transactions and gives us a
+    # PHID to retrieve them.
+    revision = phabdouble.revision(comments=[])
+    transactions = list(transaction_search(phab, revision["phid"]))
+    assert transactions == []
+
+
+def test_paginated_transactions_are_fetched_too(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    # Adding comments to a revision generates transactions and gives us a
+    # PHID to retrieve them.
+    comments = list(string.ascii_letters)
+    revision = phabdouble.revision(comments=comments)
+    # Limit the retrieved page size to force multiple API calls.
+    transactions = list(transaction_search(phab, revision["phid"], limit=1))
+    txn_comments = [get_raw_comments(t).pop() for t in transactions]
+    assert txn_comments == comments

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -6,13 +6,26 @@ import string
 from landoapi.transactions import transaction_search, get_raw_comments
 
 
-def test_transaction_search(phabdouble):
+def test_transaction_search_for_all_transactions(phabdouble):
     phab = phabdouble.get_phabricator_client()
     revision = phabdouble.revision()
     new_txn1 = phabdouble.transaction("create", revision)
     new_txn2 = phabdouble.transaction("accept", revision)
     transactions = list(transaction_search(phab, revision["phid"]))
     assert transactions == [new_txn1, new_txn2]
+
+
+def test_transaction_search_for_specific_transaction(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    revision = phabdouble.revision()
+    phabdouble.transaction("create", revision)
+    accept_txn = phabdouble.transaction("accept", revision)
+    transactions = list(
+        transaction_search(
+            phab, revision["phid"], transaction_phids=[accept_txn["phid"]]
+        )
+    )
+    assert transactions == [accept_txn]
 
 
 def test_no_transaction_search_results_returns_empty_list(phabdouble):

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,16 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import string
 
-from landoapi.transactions import transaction_search, get_raw_comments
+from landoapi.transactions import get_raw_comments, transaction_search
 
 
 def test_transaction_search_for_all_transactions(phabdouble):
     phab = phabdouble.get_phabricator_client()
     revision = phabdouble.revision()
-    new_txn1 = phabdouble.transaction("create", revision)
-    new_txn2 = phabdouble.transaction("accept", revision)
+    new_txn1 = phabdouble.transaction("dummy", revision)
+    new_txn2 = phabdouble.transaction("dummy", revision)
     transactions = list(transaction_search(phab, revision["phid"]))
     assert transactions == [new_txn1, new_txn2]
 
@@ -18,14 +17,14 @@ def test_transaction_search_for_all_transactions(phabdouble):
 def test_transaction_search_for_specific_transaction(phabdouble):
     phab = phabdouble.get_phabricator_client()
     revision = phabdouble.revision()
-    phabdouble.transaction("create", revision)
-    accept_txn = phabdouble.transaction("accept", revision)
+    phabdouble.transaction("dummy", revision)
+    target_txn = phabdouble.transaction("dummy", revision)
     transactions = list(
         transaction_search(
-            phab, revision["phid"], transaction_phids=[accept_txn["phid"]]
+            phab, revision["phid"], transaction_phids=[target_txn["phid"]]
         )
     )
-    assert transactions == [accept_txn]
+    assert transactions == [target_txn]
 
 
 def test_no_transaction_search_results_returns_empty_list(phabdouble):
@@ -38,7 +37,7 @@ def test_paginated_transactions_are_fetched_too(phabdouble):
     phab = phabdouble.get_phabricator_client()
     revision = phabdouble.revision()
     new_transactions = list(
-        phabdouble.transaction(c, revision) for c in string.ascii_letters
+        phabdouble.transaction("dummy", revision) for _ in range(10)
     )
     # Limit the retrieved page size to force multiple API calls.
     transactions = list(transaction_search(phab, revision["phid"], limit=1))


### PR DESCRIPTION
Wrap the Phabricator API's 'transaction.search' endpoint with some
useful functions.