### PR TITLE
stacks: provide a more specific error message when no repo is specifed for a revision (Bug 1569721) r?smacleod

### DIFF
--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -169,10 +169,16 @@ def calculate_landable_subgraphs(
     # We won't land anything that has a repository we don't support, so make
     # a pass over all the revisions and block these.
     for phid, revision in revision_data.revisions.items():
-        if (
-            PhabricatorClient.expect(revision, "fields", "repositoryPHID")
-            not in landable_repos
-        ):
+        repo = PhabricatorClient.expect(revision, "fields", "repositoryPHID")
+        if not repo:
+            block(
+                phid,
+                "Revision's repository unset. Specify a target using"
+                '"Edit revision" in Phabricator',
+            )
+            continue
+
+        if repo not in landable_repos:
             block(phid, "Repository is not supported by Lando.")
 
     # We only want to consider paths starting from the open revisions

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -550,6 +550,31 @@ def test_calculate_landable_subgraphs_extra_check(phabdouble):
     assert blocked[r3["phid"]] == REASON
 
 
+def test_calculate_landable_subgraphs_missing_repo(phabdouble):
+    """Test to assert a missing repository for a revision is
+    blocked with an appropriate error
+    """
+    phab = phabdouble.get_phabricator_client()
+    repo1 = phabdouble.repo()
+    r1 = phabdouble.revision(repo=None)
+
+    nodes, edges = build_stack_graph(phab, r1["phid"])
+    revision_data = request_extended_revision_data(phab, [r1["phid"]])
+
+    landable, blocked = calculate_landable_subgraphs(
+        revision_data, edges, {repo1["phid"]}
+    )
+
+    repo_unset_warning = (
+        "Revision's repository unset. Specify a target using"
+        '"Edit revision" in Phabricator'
+    )
+
+    assert not landable
+    assert r1["phid"] in blocked
+    assert blocked[r1["phid"]] == repo_unset_warning
+
+
 def test_get_landable_repos_for_revision_data(phabdouble, mocked_repo_config):
     phab = phabdouble.get_phabricator_client()
 


### PR DESCRIPTION
In `calculate_landable_subgraphs` we iterate over the repository
values attached to the revisions in our stack and check if the
repo is valid using `repo not in landable_repos`. This blocks
the revision from landing and displays a sensible error message
about an unsupported repo.

However, in the case a repo has not been associated with a
revision, the condition will still be true as the empty value is
not in the set of landable repos. This causes confusion to end
users regarding what to do to fix the problem. In this commit we
add an extra check to assert the value of `repo` is not a
False-y value. If the value is False-y, we provide a more instructive
error message and block the revision from landing. Otherwise,
we continue with the existing block logic.