### PR TITLE
tests: add a phabdouble helper to convert mocks to API search results

### DIFF
--- a/tests/test_secapproval.py
+++ b/tests/test_secapproval.py
@@ -29,12 +29,7 @@ def test_send_sanitized_commit_message(phabdouble, sec_approval_project):
 
 
 def test_build_sec_approval_request_obj(phabdouble):
-    phab = phabdouble.get_phabricator_client()
-    built_revision = phabdouble.revision()
-    response = phab.call_conduit(
-        "differential.revision.search", constraints={"phid": built_revision["phid"]}
-    )
-    api_revision = phab.single(response, "data")
+    revision = phabdouble.api_object_for(phabdouble.revision())
     # Simulate the transactions that take place when a sec-approval request
     # is made for a revision in Phabricator.
     transactions = [
@@ -46,11 +41,11 @@ def test_build_sec_approval_request_obj(phabdouble):
         },
     ]
 
-    sec_approval_request = SecApprovalRequest.build(api_revision, transactions)
+    sec_approval_request = SecApprovalRequest.build(revision, transactions)
 
     assert sec_approval_request.comment_candidates == [
         "PHID-XACT-DREV-faketxn1",
         "PHID-XACT-DREV-faketxn2",
     ]
-    assert sec_approval_request.revision_id == api_revision["id"]
-    assert sec_approval_request.diff_phid == api_revision["fields"]["diffPHID"]
+    assert sec_approval_request.revision_id == revision["id"]
+    assert sec_approval_request.diff_phid == revision["fields"]["diffPHID"]


### PR DESCRIPTION
Add a PhabricatorDouble method that takes a mock object produced by
the PhabricatorDouble factory methods and returns the same object as it
would appear in a Phabricator API search result.

Refactor existing test code to use the new method.