### PR TITLE
tests: transactions can be searched by object name

### DIFF
--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1165,6 +1165,22 @@ class PhabricatorDouble:
 
             objectIdentifier = matches[0]["phid"]
 
+        # Transactions are special. You can't retrieve them directly using search. I
+        # don't know why. You have to retrieve the transaction's parent object instead.
+        if objectIdentifier.startswith("PHID-XACT-"):
+            error_info = '[Invalid Translation!] Object "%s" does not implement "%s", so transactions can not be loaded for it.'  # noqa
+            raise PhabricatorAPIException(
+                error_info, error_code="ERR-CONDUIT-CORE", error_info=error_info
+            )
+
+        # Comments are special. You can't retrieve them directly using search. You
+        # have to retrieve the comment's parent object instead.
+        if objectIdentifier.startswith("PHID-XCMT-"):
+            error_info = f'No object "{objectIdentifier}" exists.'
+            raise PhabricatorAPIException(
+                error_info, error_code="ERR-CONDUIT-CORE", error_info=error_info
+            )
+
         items = [i for i in items if i["objectPHID"] == objectIdentifier]
 
         if constraints and "phids" in constraints:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -52,3 +52,19 @@ def test_add_comments_to_revision_generates_transactions(phabdouble):
     txn_comments = [get_raw_comments(t).pop() for t in transactions]
     assert len(transactions) == len(comments)
     assert txn_comments == comments
+
+
+def test_find_transaction_by_object_name(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    revision = phabdouble.revision()
+    txn = phabdouble.transaction("dummy", revision)
+    name = f"D{revision['id']}"
+    assert list(transaction_search(phab, name)) == [txn]
+
+
+def test_find_transaction_by_phid(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    revision = phabdouble.revision()
+    txn = phabdouble.transaction("dummy", revision)
+    phid = revision["phid"]
+    assert list(transaction_search(phab, phid)) == [txn]


### PR DESCRIPTION
Transaction objects can now be searched for by both PHID and by
object name, such as "D123".  This is necessary for situations where
only the object name is locally available without a network
request. It also matches the Phabricator API, which allows searches
by both PHID and object name.