### PR TITLE
api: exclude sec-approval from the reviewers list (bug 1590225)

### DIFF
--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -139,3 +139,13 @@ def serialize_reviewers(
         )
 
     return reviewers
+
+
+def reviewers_for_commit_message(reviewers, users, projects, sec_approval_phid):
+    # The sec-approval group must not appear in the commit message
+    # reviewers list (Bug 1590225), so we'll need to filter it.
+    return [
+        reviewer_identity(phid, users, projects).identifier
+        for phid, r in reviewers.items()
+        if (phid != sec_approval_phid and r["status"] is ReviewerStatus.ACCEPTED)
+    ]

--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -4,6 +4,7 @@
 
 import logging
 from collections import namedtuple
+from typing import List
 
 from landoapi.phabricator import (
     PhabricatorClient,
@@ -141,7 +142,22 @@ def serialize_reviewers(
     return reviewers
 
 
-def reviewers_for_commit_message(reviewers, users, projects, sec_approval_phid):
+def reviewers_for_commit_message(
+    reviewers: dict, users: List[dict], projects: List[dict], sec_approval_phid: str
+) -> List[str]:
+    """Turn a list of reviewer objects into a list of reviewer names.
+
+    The list holds reviewers that accepted the revision.
+
+    Args:
+        reviewers: Dict of {reviewer_phid: reviewer_data}
+        users: List of Phabricator Users that were involved in the revision.
+        projects: List of Phabricator Projects that were involved in the revision.
+        sec_approval_phid: The PHID string of the sec-approval project.
+
+    Returns:
+        A list of strings.
+    """
     # The sec-approval group must not appear in the commit message
     # reviewers list (Bug 1590225), so we'll need to filter it.
     return [

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -72,23 +72,6 @@ def test_secure_api_flag_on_secure_revision_is_true(client, phabdouble, secure_p
     assert response_revision["is_secure"]
 
 
-def test_sec_approval_group_is_excluded_from_reviewers_list(
-    client, phabdouble, secure_project, sec_approval_project
-):
-    revision = phabdouble.revision(projects=[secure_project])
-
-    user = phabdouble.user(username="normal_reviewer")
-    phabdouble.reviewer(revision, user)
-    phabdouble.reviewer(revision, sec_approval_project)
-
-    response = client.get("/stacks/D{}".format(revision["id"]))
-    assert response == 200
-
-    response_revision = response.json["revisions"].pop()
-    assert response_revision["is_secure"]
-    assert sec_approval_project["name"] not in response_revision["commit_message_title"]
-
-
 def test_public_revision_is_not_secure(phabdouble, secure_project):
     public_project = phabdouble.project("public")
     revision = phabdouble.api_object_for(

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -2,13 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import os
-from io import BytesIO
 from unittest.mock import MagicMock
 
 import pytest
 
 from landoapi import patches
-from landoapi.hgexports import PatchHelper
 from landoapi.mocks.canned_responses.auth0 import CANNED_USERINFO
 from landoapi.models.transplant import Transplant, TransplantStatus
 from landoapi.phabricator import ReviewerStatus, RevisionStatus
@@ -781,9 +779,8 @@ def test_integrated_transplant_sec_approval_group_is_excluded_from_reviewers_lis
     patch = s3.Object(
         app.config["PATCH_BUCKET_NAME"], patches.name(revision["id"], diff["id"])
     )
-    patch = PatchHelper(BytesIO(patch.get()["Body"].read()))
-    title, summary = patch.commit_description().decode().split("\n", maxsplit=1)
-    assert sec_approval_project["name"] not in title
+    patch_text = patch.get()["Body"].read().decode()
+    assert sec_approval_project["name"] not in patch_text
 
 
 def test_display_branch_head():


### PR DESCRIPTION
Exclude the sec-approval team from the list of code reviewers when displaying a
commit message in the UI and when building a commit message to send to the
transplant service.  This allows the sec-approval team to consult on a change 
without revealing the security-sensitive nature of the patch in the public
commit message.