### PR TITLE
repos: make test-repo landable again

### DIFF
--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -62,7 +62,7 @@ REPO_CONFIG = {
     # }
     "default": {},
     "localdev": {
-        "localdev": Repo("localdev", SCM_LEVEL_1, "", "http://hg.test"),
+        "test-repo": Repo("test-repo", SCM_LEVEL_1, "", "http://hg.test"),
         # Approval is required for the uplift dev repo
         "uplift-target": Repo("uplift-target", SCM_LEVEL_1, "", "http://hg.test", True),
     },


### PR DESCRIPTION
The conduit suite uses the repository named 'test-repo' for live testing.
test-repo was made unlandable in a prior commit.  Fix the repo name registry 
so test-repo is landable again.