### PR TITLE
commit message: allow single period in nickname (bug 1515217)

### DIFF
--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -39,7 +39,7 @@ LIST = r"[;,\/\\]\s*"
 
 # Note that we only allows a subset of legal IRC-nick characters.
 # Specifically, we do not allow [ \ ] ^ ` { | }
-IRC_NICK = r"[a-zA-Z0-9\-\_]+"
+IRC_NICK = r"[a-zA-Z0-9\-\_.]*[a-zA-Z0-9\-\_]+"
 
 # fmt: off
 REVIEWERS_RE = re.compile(  # noqa: E131


### PR DESCRIPTION
Fix that prevents Lando from mangling the reviewer names when there is a period. See https://bugzilla.mozilla.org/show_bug.cgi?id=1515217 for more info.