### PR TITLE
[sec-approval#1] api: rename landoapi.api.revisions

### DIFF
--- a/landoapi/api/secapproval.py
+++ b/landoapi/api/secapproval.py
@@ -6,7 +6,6 @@ import logging
 
 from connexion import problem
 from flask import g
-
 from landoapi import auth
 from landoapi.decorators import require_phabricator_api_key
 from landoapi.models import SecApprovalRequest

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -188,7 +188,7 @@ paths:
               - $ref: '#/definitions/Error'
   /requestSecApproval:
     post:
-      operationId: landoapi.api.revisions.request_sec_approval
+      operationId: landoapi.api.secapproval.request_sec_approval
       description: |
         Submit a sanitized, safe-to-land commit message for a security-sensitive
         revision. This starts the Security Bug Approval Process.

--- a/tests/test_sanitized_commit_messages.py
+++ b/tests/test_sanitized_commit_messages.py
@@ -363,7 +363,7 @@ def _make_sec_approval_request(
         return [comment_txn, review_txn]
 
     monkeypatch.setattr(
-        "landoapi.api.revisions.send_sanitized_commit_message_for_review",
+        "landoapi.api.secapproval.send_sanitized_commit_message_for_review",
         fake_send_message_for_review,
     )
 


### PR DESCRIPTION
Clarify the name of the landoapi.api.revisions module.  It only contains
secapproval code so we'll rename it to match.  This also adds symmetry
with the uplift API module.