### PR TITLE
WIP [sec-approval#2] api: rename requestSecApproval

### DIFF
--- a/landoapi/api/secapproval.py
+++ b/landoapi/api/secapproval.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @auth.require_auth0(scopes=("lando",))
 @require_phabricator_api_key(optional=False)
-def request_sec_approval(data=None):
+def request_sec_approval_for_commit_message(data=None):
     """Update a Revision with a sanitized commit message.
 
     Kicks off the sec-approval process.
@@ -38,7 +38,7 @@ def request_sec_approval(data=None):
     alt_message = data["sanitized_message"]
 
     logger.info(
-        "Got request for sec-approval review of revision",
+        "Got request for sec-approval review of commit message",
         extra=dict(revision_phid=revision_id),
     )
 

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -186,9 +186,9 @@ paths:
           schema:
             allOf:
               - $ref: '#/definitions/Error'
-  /requestSecApproval:
+  /requestSecApprovalForCommitMessage:
     post:
-      operationId: landoapi.api.secapproval.request_sec_approval
+      operationId: landoapi.api.secapproval.request_sec_approval_for_commit_message
       description: |
         Submit a sanitized, safe-to-land commit message for a security-sensitive
         revision. This starts the Security Bug Approval Process.

--- a/tests/test_sanitized_commit_messages.py
+++ b/tests/test_sanitized_commit_messages.py
@@ -36,12 +36,12 @@ def monogram(revision):
     return f"D{revision['id']}"
 
 
-def test_integrated_request_sec_approval(
+def test_integrated_request_sec_approval_for_commit_message(
     client, authed_headers, db, phabdouble, secure_project, sec_approval_project
 ):
     revision = phabdouble.revision(projects=[secure_project])
     response = client.post(
-        "/requestSecApproval",
+        "/requestSecApprovalForCommitMessage",
         json={"revision_id": monogram(revision), "sanitized_message": "obscure"},
         headers=authed_headers,
     )
@@ -55,7 +55,7 @@ def test_integrated_public_revisions_cannot_be_submitted_for_sec_approval(
     public_project = phabdouble.project("public")
     revision = phabdouble.revision(projects=[public_project])
     response = client.post(
-        "/requestSecApproval",
+        "/requestSecApprovalForCommitMessage",
         json={"revision_id": monogram(revision), "sanitized_message": "oops"},
         headers=authed_headers,
     )
@@ -68,7 +68,7 @@ def test_integrated_empty_commit_message_is_an_error(
 ):
     revision = phabdouble.revision(projects=[secure_project])
     response = client.post(
-        "/requestSecApproval",
+        "/requestSecApprovalForCommitMessage",
         json={"revision_id": monogram(revision), "sanitized_message": ""},
         headers=authed_headers,
     )
@@ -369,7 +369,7 @@ def _make_sec_approval_request(
 
     # Post the sec-approval request so that it gets saved into the database.
     response = client.post(
-        "/requestSecApproval",
+        "/requestSecApprovalForCommitMessage",
         json={
             "revision_id": monogram(secure_revision),
             "sanitized_message": sanitized_commit_message,


### PR DESCRIPTION
Rename the requestSecApproval method to the more specific
requestSecApprovalForCommitMessage.  Moving the old name aside allows us
 to use the original endpoint name for sec-approval form submission.