### PR TITLE
WIP [sec-approval#3] api: add a sec-approval form submission endpoint (bug 1598748)

### DIFF
--- a/landoapi/api/secapproval.py
+++ b/landoapi/api/secapproval.py
@@ -10,7 +10,7 @@ from landoapi import auth
 from landoapi.decorators import require_phabricator_api_key
 from landoapi.models import SecApprovalRequest
 from landoapi.phabricator import PhabricatorClient
-from landoapi.projects import get_secure_project_phid
+from landoapi.projects import get_sec_approval_project_phid, get_secure_project_phid
 from landoapi.revisions import revision_is_secure
 from landoapi.secapproval import build_transactions_for_request
 from landoapi.storage import db
@@ -86,7 +86,7 @@ def request_sec_approval(data=None):
         )
 
     logger.info(
-        "Got request for sec-approval review of revision",
+        "sec-approval: got request for security review of revision",
         extra=dict(
             revision_phid=revision_id,
             update_existing_request=update_existing_request,
@@ -119,7 +119,7 @@ def request_sec_approval(data=None):
 
 def _submit_form_and_request_approval(form_content, phab, revision):
     desired_edits = build_transactions_for_request(
-        form_content, "", get_secure_project_phid(phab)
+        form_content, "", get_sec_approval_project_phid(phab)
     )
     phab.call_conduit(
         "differential.revision.edit",
@@ -130,7 +130,7 @@ def _submit_form_and_request_approval(form_content, phab, revision):
 
 def _submit_alt_message_and_request_approval(alt_message, phab, revision):
     desired_edits = build_transactions_for_request(
-        "", alt_message, get_secure_project_phid(phab)
+        "", alt_message, get_sec_approval_project_phid(phab)
     )
     response = phab.call_conduit(
         "differential.revision.edit",

--- a/landoapi/api/secapproval.py
+++ b/landoapi/api/secapproval.py
@@ -9,9 +9,10 @@ from flask import g
 from landoapi import auth
 from landoapi.decorators import require_phabricator_api_key
 from landoapi.models import SecApprovalRequest
+from landoapi.phabricator import PhabricatorClient
 from landoapi.projects import get_secure_project_phid
 from landoapi.revisions import revision_is_secure
-from landoapi.secapproval import send_sanitized_commit_message_for_review
+from landoapi.secapproval import build_transactions_for_request
 from landoapi.storage import db
 from landoapi.validation import revision_id_to_int
 
@@ -21,34 +22,15 @@ logger = logging.getLogger(__name__)
 @auth.require_auth0(scopes=("lando",))
 @require_phabricator_api_key(optional=False)
 def request_sec_approval(data=None):
-    """Update a Revision with a sanitized commit message.
+    """Request Security Approval from the Firefox security team for a Revision.
 
     Kicks off the sec-approval process.
 
     See https://wiki.mozilla.org/Security/Bug_Approval_Process.
-
-    Args:
-        revision_id: The ID of the revision that will have a sanitized commit
-            message. e.g. D1234.
-        sanitized_message: The sanitized commit message.
     """
     phab = g.phabricator
 
     revision_id = revision_id_to_int(data["revision_id"])
-    alt_message = data["sanitized_message"]
-
-    logger.info(
-        "Got request for sec-approval review of revision",
-        extra=dict(revision_phid=revision_id),
-    )
-
-    if not alt_message:
-        return problem(
-            400,
-            "Empty commit message text",
-            "The sanitized commit message text cannot be empty",
-            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
-        )
 
     # FIXME: this is repeated in numerous places in the code. Needs refactoring!
     revision = phab.call_conduit(
@@ -65,27 +47,94 @@ def request_sec_approval(data=None):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
         )
 
-    # Only secure revisions are allowed to follow the sec-approval process.
-    if not revision_is_secure(revision, get_secure_project_phid(phab)):
+    form_content = data.get("form_content", "")
+    alt_message = data.get("sanitized_message", "")
+
+    update_existing_request = SecApprovalRequest.exists_for_revision(revision)
+    create_new_request = not update_existing_request
+
+    if create_new_request and not form_content:
+        return problem(
+            400,
+            "Empty sec-approval request form",
+            "The sec-approval form content cannot be empty",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )
+    elif create_new_request and not revision_is_secure(
+        revision, get_secure_project_phid(phab)
+    ):
         return problem(
             400,
             "Operation only allowed for secure revisions",
-            "Only security-sensitive revisions can be given sanitized commit messages",
+            "Only security-sensitive revisions can ask for sec-approval",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )
+    elif update_existing_request and form_content:
+        return problem(
+            400,
+            "Sec-approval request already in progress",
+            "You cannot submit a sec-approval request form for a revision where a "
+            "sec-approval request is already in progress.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )
+    elif update_existing_request and not alt_message:
+        return problem(
+            400,
+            "Empty commit message text",
+            "The sanitized commit message text cannot be empty",
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
-    resulting_transactions = send_sanitized_commit_message_for_review(
-        revision["phid"], alt_message, phab
+    logger.info(
+        "Got request for sec-approval review of revision",
+        extra=dict(
+            revision_phid=revision_id,
+            update_existing_request=update_existing_request,
+            form_was_submitted=bool(form_content),
+            alt_message_was_submitted=bool(alt_message),
+        ),
     )
 
-    # Save the transactions that added the sec-approval comment so we can
-    # quickly fetch the comment from Phabricator later in the process.
-    #
-    # NOTE: Each call to Phabricator returns two transactions: one for adding the
-    # comment and one for adding the reviewer.  We don't know which transaction is
-    # which at this point so we record both of them.
-    sa_request = SecApprovalRequest.build(revision, resulting_transactions)
-    db.session.add(sa_request)
+    if form_content:
+        _submit_form_and_request_approval(form_content, phab, revision)
+        alt_message_candidate_txn_ids = []
+        sa_request = SecApprovalRequest.build(revision, alt_message_candidate_txn_ids)
+        db.session.add(sa_request)
+
+    if alt_message:
+        alt_message_candidate_txn_ids = _submit_alt_message_and_request_approval(
+            alt_message, phab, revision
+        )
+        # NOTE: Each call to Phabricator returns at least two transactions: one for
+        # adding the comment and one for adding the reviewer.  We don't know which
+        # transaction holds our secure commit message at this point so we record all of
+        # them.
+        sa_request = SecApprovalRequest.build(revision, alt_message_candidate_txn_ids)
+        db.session.add(sa_request)
+
     db.session.commit()
 
     return {}, 200
+
+
+def _submit_form_and_request_approval(form_content, phab, revision):
+    desired_edits = build_transactions_for_request(
+        form_content, "", get_secure_project_phid(phab)
+    )
+    phab.call_conduit(
+        "differential.revision.edit",
+        objectIdentifier=(revision["phid"]),
+        transactions=desired_edits,
+    )
+
+
+def _submit_alt_message_and_request_approval(alt_message, phab, revision):
+    desired_edits = build_transactions_for_request(
+        "", alt_message, get_secure_project_phid(phab)
+    )
+    response = phab.call_conduit(
+        "differential.revision.edit",
+        objectIdentifier=(revision["phid"]),
+        transactions=desired_edits,
+    )
+    return PhabricatorClient.expect(response, "transactions")

--- a/landoapi/revisions.py
+++ b/landoapi/revisions.py
@@ -213,7 +213,7 @@ def find_title_and_summary_for_display(
             revision
         )
 
-        if sec_approval_request:
+        if sec_approval_request and sec_approval_request.comment_candidates:
             # We have requested a new title and possibly a new summary, too, for the
             # commit.
 
@@ -293,7 +293,7 @@ def find_title_and_summary_for_landing(
             revision
         )
 
-        if sec_approval_request:
+        if sec_approval_request and sec_approval_request.comment_candidates:
             # We have requested a new title and possibly a new summary, too, for the
             # commit.
 

--- a/landoapi/secapproval.py
+++ b/landoapi/secapproval.py
@@ -138,6 +138,10 @@ def search_sec_approval_request_for_comment(
     phab: PhabricatorClient, sec_approval_request: SecApprovalRequest
 ) -> Comment:
     """Search Phabricator for the comment transaction from a sec-approval request."""
+    assert (
+        sec_approval_request.comment_candidates
+    ), "attempted to search all revision comments without providing a PHID constraint"
+
     object_identifier = f"D{sec_approval_request.revision_id}"
     for transaction in transaction_search(
         phab, object_identifier, sec_approval_request.comment_candidates

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -190,7 +190,7 @@ paths:
     post:
       operationId: landoapi.api.secapproval.request_sec_approval
       description: |
-        Submit a sanitized, safe-to-land commit message for a security-sensitive
+        Submit a sec-approval request for a security-sensitive
         revision. This starts the Security Bug Approval Process.
       parameters:
         - name: data
@@ -201,12 +201,17 @@ paths:
             type: object
             required:
               - revision_id
-              - sanitized_message
             properties:
               revision_id:
                 type: string
                 description: |
                   The ID of a revision in the form of 'D{number}', e.g. 'D12345'.
+              form_content:
+                type: string
+                description: |
+                  The revison author's answers to the sec-approval team's pre-review
+                  questions. Expected to be a Phabricator ReMarkup string we can
+                  post to Phabricator as a comment.
               sanitized_message:
                 type: string
                 description: |

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -3,8 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-
-from landoapi.phabricator import RevisionStatus, ReviewerStatus
+from landoapi.phabricator import ReviewerStatus, RevisionStatus
 from landoapi.repos import get_repos_for_env
 from landoapi.revisions import (
     check_author_planned_changes,


### PR DESCRIPTION
Add a new API endpoint that generates a sec-approval request for a
revision. The request includes the user's answers to the security review
 questionnaire.

The original sec-approval request code has been left in the codebase to keep the size of this patch small.  It will be removed in follow-up PRs.