### PR TITLE
WIP [sec-approval#2] api: reorganize security properties of API Revision objects (bug 1598748)

### DIFF
--- a/landoapi/models/secapproval.py
+++ b/landoapi/models/secapproval.py
@@ -5,11 +5,9 @@
 
 See See https://wiki.mozilla.org/Security/Bug_Approval_Process.
 """
-
-from sqlalchemy.dialects.postgresql.json import JSONB
-
 from landoapi.phabricator import PhabricatorClient
 from landoapi.storage import db
+from sqlalchemy.dialects.postgresql.json import JSONB
 
 
 class SecApprovalRequest(db.Model):
@@ -60,6 +58,13 @@ class SecApprovalRequest(db.Model):
             diff_phid=PhabricatorClient.expect(revision, "fields", "diffPHID"),
             comment_candidates=possible_comment_phids,
         )
+
+    @classmethod
+    def exists_for_revision(cls, revision) -> bool:
+        """Does a sec-approval request exist for the given revision?"""
+        return db.session.query(
+            cls.query.filter_by(revision_id=revision["id"]).exists()
+        ).scalar()
 
     @classmethod
     def most_recent_request_for_revision(cls, revision) -> "SecApprovalRequest":

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -498,20 +498,33 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Reviewer'
-      is_secure:
-        type: boolean
+      security:
+        type: object
         description: |
-          Indicates this revision is security-sensitive and should follow the
-          Security Bug Approval Process.  See https://wiki.mozilla.org/Security/Bug_Approval_Process.
-      is_using_secure_commit_message:
-        type: boolean
-        description: |
-          Indicates that the patch author has given an alternative, secure commit
-          message to land this revision with, according to the Security Bug Approval
-          Process. The alternative message is available in the 'title' and
-          'summary' attributes.
+          Properties related to the secure handling of this object.
+        properties:
+          is_secure:
+            type: boolean
+            description: |
+              This revision is security-sensitive and should follow the Security Bug
+              Approval Process.
 
-          See https://wiki.mozilla.org/Security/Bug_Approval_Process for details.
+              See https://wiki.mozilla.org/Security/Bug_Approval_Process for details.
+          has_security_review:
+            type: boolean
+            description: |
+              The patch author has requested a security review for this revision.
+
+              See https://wiki.mozilla.org/Security/Bug_Approval_Process for details.
+          has_secure_commit_message:
+            type: boolean
+            description: |
+              The patch author has given an alternative secure commit message to land
+              this revision with.  The message should follow the guidelines in the
+              Security Bug Approval Process. The alternative message is available in the
+              'title' and 'summary' attributes of this object.
+
+              See https://wiki.mozilla.org/Security/Bug_Approval_Process for details.
   User:
     type: object
     properties:

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -61,7 +61,7 @@ def test_secure_api_flag_on_public_revision_is_false(client, phabdouble):
 
     assert response.status_code == 200
     response_revision = response.json["revisions"].pop()
-    assert not response_revision["is_secure"]
+    assert not response_revision["security"]["is_secure"]
 
 
 def test_secure_api_flag_on_secure_revision_is_true(
@@ -73,7 +73,7 @@ def test_secure_api_flag_on_secure_revision_is_true(
 
     assert response.status_code == 200
     response_revision = response.json["revisions"].pop()
-    assert response_revision["is_secure"]
+    assert response_revision["security"]["is_secure"]
 
 
 def test_public_revision_is_not_secure(phabdouble, secure_project):

--- a/tests/test_sanitized_commit_messages.py
+++ b/tests/test_sanitized_commit_messages.py
@@ -104,8 +104,8 @@ def test_integrated_secure_stack_has_alternate_commit_message(
     assert response == 200
 
     revision = PhabricatorClient.single(response.json, "revisions")
-    assert revision["is_secure"]
-    assert revision["is_using_secure_commit_message"]
+    assert revision["security"]["is_secure"]
+    assert revision["security"]["has_secure_commit_message"]
     assert revision["title"] == sanitized_title
     assert revision["summary"] == ""
 
@@ -122,8 +122,8 @@ def test_integrated_secure_stack_without_sec_approval_does_not_use_secure_messag
     assert response == 200
 
     revision = PhabricatorClient.single(response.json, "revisions")
-    assert revision["is_secure"]
-    assert not revision["is_using_secure_commit_message"]
+    assert revision["security"]["is_secure"]
+    assert not revision["security"]["has_secure_commit_message"]
 
 
 def test_integrated_sec_approval_transplant_uses_alternate_message(

--- a/tests/test_sec_approval_request.py
+++ b/tests/test_sec_approval_request.py
@@ -1,0 +1,92 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import pytest
+from landoapi.models import SecApprovalRequest
+from landoapi.secapproval import SECURE_COMMENT_TEMPLATE
+from landoapi.storage import db
+
+
+@pytest.fixture(autouse=True)
+def preamble(app, db, monkeypatch):
+    # All API acceptance tests need the 'app' fixture to function.
+
+    # Mock a valid API token.
+    monkeypatch.setattr(
+        "landoapi.decorators.PhabricatorClient.verify_api_token",
+        lambda *args, **kwargs: True,
+    )
+
+
+@pytest.fixture
+def authed_headers(auth0_mock):
+    """Return a set of Auth0 and Phabricator auth'd headers for use by the test client.
+    """
+    headers = auth0_mock.mock_headers.copy()
+    headers.append(("X-Phabricator-API-Key", "custom-key"))
+    return headers
+
+
+def monogram(revision):
+    """Returns the monogram for a Phabricator API revision object.
+
+    For example, a revision with ID 567 returns "D567".
+    """
+    return f"D{revision['id']}"
+
+
+def test_integrated_stack_reports_sec_approval_in_progress(
+    client, authed_headers, phabdouble, secure_project, sec_approval_project
+):
+    revision = _setup_inprogress_sec_approval_request(
+        "", "original insecure title", phabdouble, secure_project
+    )
+
+    # Sanity check to ensure the system thinks a review is already in progress.
+    response = client.get(f"/stacks/{monogram(revision)}", headers=authed_headers)
+    assert response == 200
+    assert response.json["revisions"][0]["security"]["has_security_review"]
+
+
+def _setup_inprogress_sec_approval_request(
+    sanitized_commit_message,
+    revision_title,
+    phabdouble,
+    secure_project,
+    sec_approval_comment_body=None,
+):
+    diff = phabdouble.diff()
+
+    # Build a specially formatted sec-approval request comment.
+    if sec_approval_comment_body is None:
+        sec_approval_comment_body = SECURE_COMMENT_TEMPLATE.format(
+            message=sanitized_commit_message
+        )
+    mock_comment = phabdouble.comment(sec_approval_comment_body)
+
+    # Build a secure revision.
+    secure_revision = phabdouble.revision(
+        diff=diff,
+        repo=phabdouble.repo(),
+        projects=[secure_project],
+        title=revision_title,
+    )
+
+    # Add the two sec-approval request transactions to Phabricator. This also links
+    # the sec-approval request comment to the secure revision.
+    comment_txn = phabdouble.api_object_for(
+        phabdouble.transaction("comment", secure_revision, comments=[mock_comment])
+    )
+    review_txn = phabdouble.api_object_for(
+        phabdouble.transaction("reviewers.add", secure_revision)
+    )
+
+    # Prime the database with our sec-approval request, as if we had made an earlier
+    # request via the API.
+    new_request = SecApprovalRequest.build(
+        phabdouble.api_object_for(secure_revision), [comment_txn, review_txn]
+    )
+    db.session.add(new_request)
+    db.session.commit()
+
+    return secure_revision

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -664,5 +664,5 @@ def test_integrated_stack_has_revision_security_status(
     assert response.status_code == 200
 
     revisions = {r["phid"]: r for r in response.json["revisions"]}
-    assert not revisions[public_revision["phid"]]["is_secure"]
-    assert revisions[secure_revision["phid"]]["is_secure"]
+    assert not revisions[public_revision["phid"]]["security"]["is_secure"]
+    assert revisions[secure_revision["phid"]]["security"]["is_secure"]


### PR DESCRIPTION
Move an API Revision object's security-related information
into a common child object.  Add a new property to indicate if
the author has requested a security review, and rename the
existing sec-approval property for clarity.