### PR TITLE
auth: update token expired message with meaningful instructions

### DIFF
--- a/landoapi/auth.py
+++ b/landoapi/auth.py
@@ -451,7 +451,7 @@ class require_auth0:
                 raise ProblemException(
                     401,
                     "Token Expired",
-                    "Appropriate token is expired",
+                    "Appropriate token is expired. Please log out and back in.",
                     type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401",
                 )
             except jwt.JWTClaimsError:


### PR DESCRIPTION
The message will include instructions on how to fix an expired token
issue. Since we have different types of tokens, users can easily mix up
what to do without more specific messaging.

This change can be reverted once no more users are impacted by the recent upgrade to `flask-pyoidc`. 