### PR TITLE
Fix repo clone subsystem requirement

### DIFF
--- a/landoapi/app.py
+++ b/landoapi/app.py
@@ -29,6 +29,7 @@ from landoapi.version import version
 
 logger = logging.getLogger(__name__)
 
+# Subsystems shared across different services
 SUBSYSTEMS = [
     # Logging & sentry first so that other systems log properly.
     logging_subsystem,


### PR DESCRIPTION
Prior to this change, all services were initialized with the same
subsystems, which causes some subsystems to stall (for example,
`RepoCloneSubsystem`) on services that don't use them and don't mount
repos. This revision adds the ability to exclude certain subsystems when
they are not needed.