### PR TITLE
landing jobs: add ability to cancel landing jobs (bug 1503000)

### DIFF
--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 def put(landing_job_id, data):
     """Update a landing job.
 
-    This method checks whether the logged in user is allowed to modify the landing job
-    that is passed, does some basic validation on the data passed, and updates the
-    landing job instance accordingly.
+    Checks whether the logged in user is allowed to modify the landing job that is
+    passed, does some basic validation on the data passed, and updates the landing job
+    instance accordingly.
 
     Args:
         landing_job_id (int): The unique ID of the LandingJob object.
@@ -60,14 +60,15 @@ def put(landing_job_id, data):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
-    if landing_job.status == LandingJobStatus.SUBMITTED:
-        landing_job.transition_status(LandingJobAction.CANCEL)
-        db.session.commit()
-        return {"id": landing_job.id}, 200
-    else:
-        raise ProblemException(
-            400,
-            "Landing job could not be cancelled.",
-            f"Landing job status ({landing_job.status}) does not allow cancelling.",
-            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
-        )
+    if data["action"] == LandingJobAction.CANCEL.value:
+        if landing_job.status == LandingJobStatus.SUBMITTED:
+            landing_job.transition_status(LandingJobAction.CANCEL)
+            db.session.commit()
+            return {"id": landing_job.id}, 200
+        else:
+            raise ProblemException(
+                400,
+                "Landing job could not be cancelled.",
+                f"Landing job status ({landing_job.status}) does not allow cancelling.",
+                type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+            )

--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -28,7 +28,7 @@ def put(landing_job_id, data):
     Raises:
         ProblemException: If a LandingJob object corresponding to the landing_job_id
             is not found, if a user is not authorized to access said LandingJob object,
-            if an invalid action is provided, or if a LandingJob object can not be
+            if an invalid status is provided, or if a LandingJob object can not be
             updated (for example, when trying to cancel a job that is already in
             progress).
     """
@@ -51,16 +51,7 @@ def put(landing_job_id, data):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403",
         )
 
-    supported_actions = [LandingJobAction.CANCEL.value]
-    if data["action"] not in supported_actions:
-        raise ProblemException(
-            400,
-            "Invalid action",
-            f"The provided action {data['action']} is not a valid action.",
-            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
-        )
-
-    if data["action"] == LandingJobAction.CANCEL.value:
+    if data["status"] == LandingJobStatus.CANCELLED.value:
         if landing_job.status == LandingJobStatus.SUBMITTED:
             landing_job.transition_status(LandingJobAction.CANCEL)
             db.session.commit()
@@ -72,3 +63,10 @@ def put(landing_job_id, data):
                 f"Landing job status ({landing_job.status}) does not allow cancelling.",
                 type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
             )
+    else:
+        raise ProblemException(
+            400,
+            "Invalid status provided",
+            f"The provided status {data['status']} is not allowed.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )

--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -1,0 +1,73 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+import logging
+
+from connexion import ProblemException
+from flask import g
+
+from landoapi import auth
+from landoapi.models.landing_job import LandingJob, LandingJobStatus, LandingJobAction
+from landoapi.storage import db
+
+logger = logging.getLogger(__name__)
+
+
+@auth.require_auth0(scopes=("lando", "profile", "email"), userinfo=True)
+def put(landing_job_id, data):
+    """Update a landing job.
+
+    This method checks whether the logged in user is allowed to modify the landing job
+    that is passed, does some basic validation on the data passed, and updates the
+    landing job instance accordingly.
+
+    Args:
+        landing_job_id (int): The unique ID of the LandingJob object.
+        data (dict): A dictionary containing the cleaned data payload from the request.
+
+    Raises:
+        ProblemException: If a LandingJob object corresponding to the landing_job_id
+            is not found, if a user is not authorized to access said LandingJob object,
+            if an invalid action is provided, or if a LandingJob object can not be
+            updated (for example, when trying to cancel a job that is already in
+            progress).
+    """
+    landing_job = LandingJob.query.with_for_update().get(landing_job_id)
+
+    if not landing_job:
+        raise ProblemException(
+            404,
+            "Landing job not found",
+            f"A landing job with ID {landing_job_id} was not found.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
+        )
+
+    ldap_username = g.auth0_user.email
+    if landing_job.requester_email != ldap_username:
+        raise ProblemException(
+            403,
+            "Unauthorized",
+            f"User not authorized to update landing job {landing_job_id}",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403",
+        )
+
+    supported_actions = [LandingJobAction.CANCEL.value]
+    if data["action"] not in supported_actions:
+        raise ProblemException(
+            400,
+            "Invalid action",
+            f"The provided action {data['action']} is not a valid action.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )
+
+    if landing_job.status == LandingJobStatus.SUBMITTED:
+        landing_job.transition_status(LandingJobAction.CANCEL)
+        db.session.commit()
+        return {"id": landing_job.id}, 200
+    else:
+        raise ProblemException(
+            400,
+            "Landing job could not be cancelled.",
+            f"Landing job status ({landing_job.status}) does not allow cancelling.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )

--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -51,22 +51,22 @@ def put(landing_job_id, data):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403",
         )
 
-    if data["status"] == LandingJobStatus.CANCELLED.value:
-        if landing_job.status == LandingJobStatus.SUBMITTED:
-            landing_job.transition_status(LandingJobAction.CANCEL)
-            db.session.commit()
-            return {"id": landing_job.id}, 200
-        else:
-            raise ProblemException(
-                400,
-                "Landing job could not be cancelled.",
-                f"Landing job status ({landing_job.status}) does not allow cancelling.",
-                type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
-            )
-    else:
+    if data["status"] != LandingJobStatus.CANCELLED.value:
         raise ProblemException(
             400,
             "Invalid status provided",
             f"The provided status {data['status']} is not allowed.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )
+
+    if landing_job.status == LandingJobStatus.SUBMITTED:
+        landing_job.transition_status(LandingJobAction.CANCEL)
+        db.session.commit()
+        return {"id": landing_job.id}, 200
+    else:
+        raise ProblemException(
+            400,
+            "Landing job could not be cancelled.",
+            f"Landing job status ({landing_job.status}) does not allow cancelling.",
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -4,6 +4,7 @@
 import datetime
 import enum
 import logging
+import os
 
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.dialects.postgresql.json import JSONB
@@ -13,7 +14,7 @@ from landoapi.storage import db
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_GRACE_SECONDS = 60 * 2
+DEFAULT_GRACE_SECONDS = os.environ.get("DEFAULT_GRACE_SECONDS", 60 * 2)
 
 
 @enum.unique

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -140,7 +140,14 @@ class LandingJob(Base):
 
     @classmethod
     def job_queue_query(cls, repositories=None, grace_seconds=DEFAULT_GRACE_SECONDS):
-        """Return a query which selects the queued jobs."""
+        """Return a query which selects the queued jobs.
+
+        Args:
+            repositories (iterable): A list of repository names to use when filtering
+                the landing job search query.
+            grace_seconds (int): Ignore landing jobs that were submitted after this
+                many seconds ago.
+        """
         applicable_statuses = (
             LandingJobStatus.SUBMITTED,
             LandingJobStatus.IN_PROGRESS,

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -13,7 +13,7 @@ from landoapi.storage import db
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_GRACE_SECONDS = 1  # 60 * 15
+DEFAULT_GRACE_SECONDS = 60 * 2
 
 
 @enum.unique

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -109,6 +109,52 @@ paths:
           schema:
             allOf:
               - $ref: '#/definitions/Error'
+  /landing_jobs/{landing_job_id}:
+    put:
+      operationId: landoapi.api.landing_jobs.put
+      description: Updates a request to land (i.e. a landing job)
+      parameters:
+        - name: landing_job_id
+          in: path
+          type: string
+          required: true
+        - name: data
+          required: true
+          in: body
+          schema:
+            type: object
+            required:
+              - action
+            properties:
+              action:
+                type: string
+                enum:
+                  - CANCEL
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: Landing Job id
+        403:
+          description: Service not authorized
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+        404:
+          description: Landing job does not exist
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+
   /landings/update:
     post:
       operationId: landoapi.api.landings.update

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -124,12 +124,12 @@ paths:
           schema:
             type: object
             required:
-              - action
+              - status
             properties:
-              action:
+              status:
                 type: string
                 enum:
-                  - CANCEL
+                  - CANCELLED
       responses:
         200:
           description: OK

--- a/tests/test_landing_job.py
+++ b/tests/test_landing_job.py
@@ -2,8 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from landoapi.models.landing_job import LandingJob, LandingJobStatus
 import pytest
+
+from landoapi.models.landing_job import LandingJob, LandingJobStatus
 
 
 @pytest.fixture

--- a/tests/test_landing_job.py
+++ b/tests/test_landing_job.py
@@ -46,7 +46,9 @@ def test_landing_job_acquire_job_job_queue_query(db):
 
     # The now IN_PROGRESS job should be first, and the cancelled job should
     # not appear in the queue.
-    queue_items = LandingJob.job_queue_query(repositories=[REPO_NAME]).all()
+    queue_items = LandingJob.job_queue_query(
+        repositories=[REPO_NAME], grace_seconds=0
+    ).all()
     assert len(queue_items) == 2
     assert queue_items[0] is jobs[2]
     assert queue_items[1] is jobs[0]


### PR DESCRIPTION
- add REST endpoint (update)
- update landing job actions enum
- add grace period functionality

See https://github.com/mozilla-conduit/lando-ui/pull/108 for UI implementation.
See https://bugzilla.mozilla.org/show_bug.cgi?id=1503000.