### PR TITLE
repos: disable local transplants on VCT (bug 1648756)

### DIFF
--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -193,7 +193,7 @@ REPO_CONFIG = {
             push_bookmark="@",
             push_path="ssh://hg.mozilla.org/hgcustom/version-control-tools",
             pull_path="https://hg.mozilla.org/hgcustom/version-control-tools",
-            transplant_locally=True,
+            transplant_locally=False,
             url="https://hg.mozilla.org/hgcustom/version-control-tools",
             config_override={"ui.ssh": SSH_CONFIG_OVERRIDES},
         ),


### PR DESCRIPTION
Temporarily disable local transplants until bug 1648485 is landed.