### PR TITLE
landing worker: send notification of failed transplants (bug 1649465)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,10 @@ jobs:
 
       - deploy:
           command: |
+            cat << EOF
+            DOCKERHUB_REPO: ${DOCKERHUB_REPO}
+            CIRCLE_BRANCH: ${CIRCLE_BRANCH}
+            EOF
             if [[ "x$DOCKERHUB_REPO" != x ]]; then
               docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
               docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}"
@@ -110,7 +114,6 @@ jobs:
                 docker push "${DOCKERHUB_REPO}:latest"
               fi
             fi
-
 workflows:
   version: 2
   main:

--- a/landoapi/api/landings.py
+++ b/landoapi/api/landings.py
@@ -61,5 +61,10 @@ def update(data):
         )
 
     if transplant.status == TransplantStatus.failed:
-        notify_user_of_landing_failure(transplant)
+        notify_user_of_landing_failure(
+            transplant.requester_email,
+            transplant.head_revision,
+            transplant.error,
+            transplant.request_id,
+        )
     return {}, 200

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -2,12 +2,32 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import mock
+import pytest
+
 from landoapi import patches
 from landoapi.hg import HgRepo
 from landoapi.landing_worker import LandingWorker
 from landoapi.models.landing_job import LandingJob, LandingJobStatus
 from landoapi.models.transplant import Transplant, TransplantStatus
 from landoapi.repos import Repo, SCM_LEVEL_3
+
+
+@pytest.fixture
+def upload_patch():
+    """A fixture that fake uploads a patch"""
+
+    def _upload_patch(number):
+        patches.upload(
+            number,
+            number,
+            PATCH_NORMAL_1,
+            "landoapi.test.bucket",
+            aws_access_key=None,
+            aws_secret_key=None,
+        )
+
+    return _upload_patch
 
 
 def test_update_landing(db, client):
@@ -147,7 +167,7 @@ diff --git a/test.txt b/test.txt
 
 
 def test_integrated_execute_job(
-    app, db, s3, mock_repo_config, hg_server, hg_clone, treestatusdouble
+    app, db, s3, mock_repo_config, hg_server, hg_clone, treestatusdouble, upload_patch
 ):
     treestatus = treestatusdouble.get_treestatus_client()
     treestatusdouble.open_tree("mozilla-central")
@@ -155,22 +175,8 @@ def test_integrated_execute_job(
         "mozilla-central", SCM_LEVEL_3, "", hg_server, hg_server, True, hg_server, False
     )
     hgrepo = HgRepo(hg_clone.strpath)
-    patches.upload(
-        1,
-        1,
-        PATCH_NORMAL_1,
-        "landoapi.test.bucket",
-        aws_access_key=None,
-        aws_secret_key=None,
-    )
-    patches.upload(
-        2,
-        2,
-        PATCH_NORMAL_2,
-        "landoapi.test.bucket",
-        aws_access_key=None,
-        aws_secret_key=None,
-    )
+    upload_patch(1)
+    upload_patch(2)
     job = LandingJob(
         status=LandingJobStatus.IN_PROGRESS,
         requester_email="test@example.com",
@@ -185,3 +191,51 @@ def test_integrated_execute_job(
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
     assert job.status is LandingJobStatus.LANDED
     assert len(job.landed_commit_id) == 40
+
+
+def test_failed_landing_job_notification(
+    app,
+    db,
+    s3,
+    mock_repo_config,
+    hg_server,
+    hg_clone,
+    treestatusdouble,
+    monkeypatch,
+    upload_patch,
+):
+    """Ensure that a failed landings triggers a user notification.
+    """
+    treestatus = treestatusdouble.get_treestatus_client()
+    treestatusdouble.open_tree("mozilla-central")
+    repo = Repo(
+        "mozilla-central", SCM_LEVEL_3, "", hg_server, hg_server, True, hg_server, False
+    )
+    hgrepo = HgRepo(hg_clone.strpath)
+    upload_patch(1)
+    upload_patch(2)
+    job = LandingJob(
+        status=LandingJobStatus.IN_PROGRESS,
+        requester_email="test@example.com",
+        repository_name="mozilla-central",
+        revision_to_diff_id={"1": 1, "2": 2},
+        revision_order=["1", "2"],
+        attempts=1,
+    )
+
+    worker = LandingWorker(sleep_seconds=0.01)
+
+    # Mock `hgrepo.update_repo` so we can force a failed landing.
+    mock_update_repo = mock.MagicMock()
+    mock_update_repo.side_effect = Exception("Forcing a failed landing")
+    monkeypatch.setattr(hgrepo, "update_repo", mock_update_repo)
+
+    # Mock `notify_user_of_landing_failure` so we can make sure that it was called.
+    mock_notify = mock.MagicMock()
+    monkeypatch.setattr(
+        "landoapi.landing_worker.notify_user_of_landing_failure", mock_notify
+    )
+
+    assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
+    assert job.status is LandingJobStatus.FAILED
+    assert mock_notify.call_count == 1

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -95,7 +95,13 @@ def test_notify_user_of_landing_failure(check_celery, app, celery_worker, smtp):
     # for an observable effect of sending emails in this test because the
     # celery_worker fixture causes the test to cross threads.  We only ensure the
     # happy-path runs cleanly.
-    notify_user_of_landing_failure(Transplant(revision_order=["1"]))
+    transplant = Transplant(revision_order=["1"])
+    notify_user_of_landing_failure(
+        transplant.requester_email,
+        transplant.head_revision,
+        transplant.error,
+        transplant.request_id,
+    )
 
 
 def test_mail_sender_whitelist_rejections(app, smtp):


### PR DESCRIPTION
Add support for email notification when a landing job fails.