### PR TITLE
repos: update repos to use landing worker (bug 1651055)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import copy
 import logging
+import os
 import shlex
 import tempfile
 import uuid
@@ -12,6 +13,10 @@ import hglib
 from landoapi.hgexports import PatchHelper
 
 logger = logging.getLogger(__name__)
+
+# Username and SSH port to use when connecting to remote HG server.
+landing_worker_username = os.environ.get("LANDING_WORKER_USERNAME", "app")
+landing_worker_target_ssh_port = os.environ.get("LANDING_WORKER_TARGET_SSH_PORT", "22")
 
 
 class HgException(Exception):
@@ -92,7 +97,14 @@ class HgRepo:
         "ui.username": "Otto Länd <bind-autoland@mozilla.com>",
         "ui.interactive": "False",
         "ui.merge": "internal:merge",
-        "ui.ssh": 'ssh -o "SendEnv AUTOLAND_REQUEST_USER"',
+        "ui.ssh": (
+            "ssh "
+            '-o "SendEnv AUTOLAND_REQUEVST_USER" '
+            '-o "StrictHostKeyChecking no" '
+            '-o "PasswordAuthentication no" '
+            f'-o "User {landing_worker_username}" '
+            f'-o "Port {landing_worker_target_ssh_port}"'
+        ),
         "extensions.purge": "",
         "extensions.strip": "",
         "extensions.rebase": "",

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import logging
-import os
 import pathlib
 import urllib
 from collections import namedtuple
@@ -66,7 +65,10 @@ class Repo:
     config_override: dict = None
 
     def __post_init__(self):
-        """Updates `push_path` and `pull_path` based on `url`, if either are missing."""
+        """Set defaults based on initial values.
+
+        Updates `push_path` and `pull_path` based on `url`, if either are missing.
+        """
         if not self.push_path or not self.pull_path:
             url = urllib.parse.urlparse(self.url)
             if not self.push_path:
@@ -116,20 +118,6 @@ SCM_FIREFOXCI = AccessGroup(
     display_name="scm_firefoxci",
 )
 
-# Username and SSH port to use when connecting to remote HG server.
-landing_worker_username = os.environ.get("LANDING_WORKER_USERNAME", "app")
-landing_worker_target_ssh_port = os.environ.get("LANDING_WORKER_TARGET_SSH_PORT", "22")
-
-# Configuration overrides that can be applied to any repo.
-SSH_CONFIG_OVERRIDES = (
-    "ssh "
-    '-o "SendEnv AUTOLAND_REQUEST_USER" '
-    '-o "StrictHostKeyChecking no" '
-    '-o "PasswordAuthentication no" '
-    f'-o "User {landing_worker_username}" '
-    f'-o "Port {landing_worker_target_ssh_port}"'
-)
-
 
 REPO_CONFIG = {
     # '<ENV>': {
@@ -158,7 +146,6 @@ REPO_CONFIG = {
             push_path="ssh://autoland.hg//repos/third-repo",
             pull_path="http://hg.test/third-repo",
             transplant_locally=True,
-            config_override={"ui.ssh": SSH_CONFIG_OVERRIDES},
         ),
         # Approval is required for the uplift dev repo
         "uplift-target": Repo(
@@ -177,7 +164,6 @@ REPO_CONFIG = {
             push_path="ssh://autolandhg.devsvcdev.mozaws.net//repos/test-repo",
             pull_path="https://autolandhg.devsvcdev.mozaws.net/test-repo",
             transplant_locally=True,
-            config_override={"ui.ssh": SSH_CONFIG_OVERRIDES},
         ),
         # A repo to test local transplants.
         "first-repo": Repo(
@@ -214,7 +200,6 @@ REPO_CONFIG = {
             access_group=SCM_VERSIONCONTROL,
             push_bookmark="@",
             transplant_locally=True,
-            config_override={"ui.ssh": SSH_CONFIG_OVERRIDES},
         ),
         "build-tools": Repo(
             tree="build-tools",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -259,24 +259,16 @@ def mocked_repo_config(mock_repo_config):
         {
             "test": {
                 "mozilla-central": Repo(
-                    "mozilla-central",
-                    SCM_LEVEL_3,
-                    "",
-                    "",
-                    "",
-                    False,
-                    "http://hg.test",
-                    False,
+                    tree="mozilla-central",
+                    url="http://hg.test",
+                    access_group=SCM_LEVEL_3,
+                    approval_required=False,
                 ),
                 "mozilla-uplift": Repo(
-                    "mozilla-uplift",
-                    SCM_LEVEL_3,
-                    "",
-                    "",
-                    "",
-                    False,
-                    "http://hg.test/uplift",
-                    True,
+                    tree="mozilla-uplift",
+                    url="http://hg.test/uplift",
+                    access_group=SCM_LEVEL_3,
+                    approval_required=True,
                 ),
             }
         }

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -152,7 +152,12 @@ def test_integrated_execute_job(
     treestatus = treestatusdouble.get_treestatus_client()
     treestatusdouble.open_tree("mozilla-central")
     repo = Repo(
-        "mozilla-central", SCM_LEVEL_3, "", hg_server, hg_server, True, hg_server, False
+        tree="mozilla-central",
+        url=hg_server,
+        access_group=SCM_LEVEL_3,
+        push_path=hg_server,
+        pull_path=hg_server,
+        transplant_locally=True,
     )
     hgrepo = HgRepo(hg_clone.strpath)
     patches.upload(

--- a/tests/test_py3_codequality.py
+++ b/tests/test_py3_codequality.py
@@ -12,7 +12,7 @@ from landoapi.cli import LINT_PATHS
 def test_check_python_style():
     cmd = ("black", "--diff")
     output = subprocess.check_output(cmd + LINT_PATHS)
-    assert not output, "The python code does not adhear to the project style."
+    assert not output, "The python code does not adhere to the project style."
 
 
 def test_check_python_flake8():

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -583,14 +583,10 @@ def test_integrated_push_bookmark_sent_when_supported_repo(
         {
             "test": {
                 "mozilla-central": Repo(
-                    "mozilla-central",
-                    SCM_LEVEL_3,
-                    "@",
-                    "",
-                    "",
-                    False,
-                    "http://hg.test",
-                    False,
+                    tree="mozilla-central",
+                    url="http://hg.test",
+                    access_group=SCM_LEVEL_3,
+                    push_bookmark="@",
                 )
             }
         }


### PR DESCRIPTION
With the exception of mozilla-central, enable local transplants on all
other repos. Also, update `Repo` to use dataclasses instead of
namedtuples. This makes it easier to set defaults and improves
readability.