### PR TITLE
stacks: add support for DONTBUILD flag (bug 1642939)

### DIFF
--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -159,26 +159,20 @@ def get(revision_id):
         short_name = PhabricatorClient.expect(
             stack_data.repositories[phid], "fields", "shortName"
         )
+
         repo = supported_repos.get(short_name)
-        if repo is None:
-            landing_supported, approval_required = False, None
-        else:
-            landing_supported, approval_required = True, repo.approval_required
-        url = (
-            "{phabricator_url}/source/{short_name}".format(
-                phabricator_url=current_app.config["PHABRICATOR_URL"],
-                short_name=short_name,
-            )
-            if not landing_supported
-            else supported_repos[short_name].url
-        )
+        landing_supported = repo is not None
+
         repositories.append(
             {
-                "phid": phid,
-                "short_name": short_name,
-                "url": url,
                 "landing_supported": landing_supported,
-                "approval_required": approval_required,
+                "approval_required": landing_supported and repo.approval_required,
+                "url": repo.url
+                if landing_supported
+                else (f"{current_app.config['PHABRICATOR_URL']}/source/{short_name}"),
+                "phid": phid,
+                "shortname": short_name,
+                "commit_flags": repo.commit_flags if repo else [],
             }
         )
 

--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -54,9 +54,17 @@ from landoapi.validation import revision_id_to_int
 logger = logging.getLogger(__name__)
 
 
-def _unmarshal_transplant_request(data):
+def _parse_transplant_request(data):
+    """Extract confirmation token, flags, and the landing path from provided data.
+
+    Args
+        data (dict): A dictionary representing the transplant request.
+
+    Returns:
+        dict: A dictionary containing the landing path, confirmation token and flags.
+    """
     try:
-        path = [
+        landing_path = [
             (revision_id_to_int(item["revision_id"]), int(item["diff_id"]))
             for item in data["landing_path"]
         ]
@@ -68,7 +76,7 @@ def _unmarshal_transplant_request(data):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
-    if not path:
+    if not landing_path:
         raise ProblemException(
             400,
             "Landing Path Required",
@@ -76,11 +84,17 @@ def _unmarshal_transplant_request(data):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
+    flags = data.get("flags", [])
+
     # Confirmation token is optional. Convert usage of an empty
     # string to None as well to make using the API easier.
     confirmation_token = data.get("confirmation_token") or None
 
-    return path, confirmation_token
+    return {
+        "landing_path": landing_path,
+        "confirmation_token": confirmation_token,
+        "flags": flags,
+    }
 
 
 def _choose_middle_revision_from_path(path):
@@ -222,7 +236,7 @@ def _lock_table_for(
 @require_phabricator_api_key(optional=True)
 def dryrun(data):
     phab = g.phabricator
-    landing_path, _ = _unmarshal_transplant_request(data)
+    landing_path = _parse_transplant_request(data)["landing_path"]
     assessment, *_ = _assess_transplant_request(phab, landing_path)
     return assessment.to_dict()
 
@@ -231,12 +245,18 @@ def dryrun(data):
 @require_phabricator_api_key(optional=True)
 def post(data):
     phab = g.phabricator
-    landing_path, confirmation_token = _unmarshal_transplant_request(data)
+
+    parsed_transplant_request = _parse_transplant_request(data)
+    confirmation_token = parsed_transplant_request["confirmation_token"]
+    flags = parsed_transplant_request["flags"]
+    landing_path = parsed_transplant_request["landing_path"]
+
     logger.info(
         "transplant requested by user",
         extra={
             "has_confirmation_token": confirmation_token is not None,
             "landing_path": landing_path,
+            "flags": flags,
         },
     )
     assessment, to_land, landing_repo, stack_data = _assess_transplant_request(
@@ -248,6 +268,14 @@ def post(data):
         raise ValueError(
             "One or more values missing in access transplant request: "
             f"{to_land}, {landing_repo}, {stack_data}"
+        )
+
+    if set(flags) - set(landing_repo.commit_flags):
+        raise ProblemException(
+            400,
+            "Invalid flags specified",
+            f"Flags must be one or more of {landing_repo.commit_flags}; {flags} provided.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
     if assessment.warnings:
@@ -306,6 +334,7 @@ def post(data):
             urllib.parse.urljoin(
                 current_app.config["PHABRICATOR_URL"], "D{}".format(revision["id"])
             ),
+            flags,
         )[1]
         author_name, author_email = select_diff_author(diff)
         date_modified = phab.expect(revision, "fields", "dateModified")

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -65,35 +65,36 @@ REVIEWERS_RE = re.compile(  # noqa: E131
 METADATA_RE = re.compile("^MozReview-Commit-ID: ")
 
 
-def format_commit_message(title, bug, reviewers, summary, revision_url):
+def format_commit_message(title, bug, reviewers, summary, revision_url, flags=None):
     """
     Creates a default format commit message using revision metadata.
 
     The default format is as follows:
-        <Bug #> - <Message Title> r=<reviewer1>,r=<reviewer2>
+        <Bug #> - <Message Title> r=<reviewer1>,r=<reviewer2> <flag1> <flag2>
 
         <Summary>
 
         Differential Revision: <Revision URL>
 
     Args:
-        title: The first line of the original commit message.
-        bug: The bug number to use or None.
-        reviewers: A list of reviewer usernames.
-        summary: A string containing the revision's summary
-        revision_url: The revision's url in Phabricator
+        title (str): The first line of the original commit message.
+        bug (str): The bug number to use or None.
+        reviewers (list of str): A list of reviewer usernames.
+        summary (str): A string containing the revision's summary.
+        revision_url (str): The revision's url in Phabricator.
+        flags (list of str): A list of flags to append to the title.
 
     Returns:
-        A tuple of strings with the formatted title and full commit message.
-        If the title already contains the bug id or reviewers, only the missing
-        part will be added, or the title will be used unmodified if it is
-        already valid.
+        tuple of str: Includes the formatted title and full commit message. If the
+            title already contains the bug id or reviewers, only the missing part
+            will be added, or the title will be used unmodified if it is already
+            valid.
     """
     if bug and bug not in parse_bugs(title):
         # All we really care about is if a bug is known it should
         # appear in the first line of the commit message. If it
         # isn't already there we'll add it.
-        title = "Bug {} - {}".format(bug, title)
+        title = f"Bug {bug} - {title}"
 
     # Ensure that the actual reviewers are recorded in the
     # first line of the commit message.
@@ -102,6 +103,10 @@ def format_commit_message(title, bug, reviewers, summary, revision_url):
     # Clear any leading / trailing whitespace.
     title = title.strip()
     summary = summary.strip()
+
+    # Append any flags to the title, as needed
+    if flags:
+        title = f"{title} {' '.join(flags)}"
 
     # Construct the final message as a series of sections with
     # a blank line between each. Blank sections are filtered out.
@@ -180,7 +185,7 @@ def strip_commit_metadata(s):
     if type(s) == bytes:
         joiner = b"\n"
     elif type(s) == str:
-        joiner = u"\n"
+        joiner = "\n"
     else:
         raise TypeError("do not know type of commit message: %s" % type(s))
 

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -49,6 +49,8 @@ class Repo:
         approval_required (bool): Whether approval is required or not for given repo.
             Note that this is not fully implemented but is included for compatibility.
             Defaults to `False`.
+        commit_flags (bool): A list of supported flags that can be appended to the
+            commit message at landing time (e.g. `["DONTBUILD"]`).
         config_override (dict): Parameters to override when loading the Mercurial
             configuration. The keys and values map directly to configuration keys and
             values. Defaults to `None`.
@@ -62,6 +64,7 @@ class Repo:
     pull_path: str = ""
     transplant_locally: bool = False
     approval_required: bool = False
+    commit_flags: list = None
     config_override: dict = None
 
     def __post_init__(self):
@@ -75,6 +78,9 @@ class Repo:
                 self.push_path = f"ssh://{url.netloc}{url.path}"
             if not self.pull_path:
                 self.pull_path = self.url
+
+        if not self.commit_flags:
+            self.commit_flags = []
 
 
 SCM_LEVEL_3 = AccessGroup(
@@ -131,8 +137,10 @@ REPO_CONFIG = {
         "first-repo": Repo(
             tree="first-repo",
             url="http://hg.test/first-repo",
+            push_path="ssh://autoland.hg//first-repo",
             access_group=SCM_LEVEL_1,
             transplant_locally=True,
+            commit_flags=["DONTBUILD"],
         ),
         "second-repo": Repo(
             tree="second-repo",

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -88,6 +88,10 @@ paths:
                       with the current warnings and the matching token. If
                       the warnings have changed between requesting a dryrun
                       and requesting a landing, the landing will fail.
+                  flags:
+                    type: array
+                    items:
+                      type: string
       responses:
         202:
           description: OK

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -272,6 +272,12 @@ def mocked_repo_config(mock_repo_config):
                     approval_required=True,
                     legacy_transplant=True,
                 ),
+                "mozilla-new": Repo(
+                    tree="mozilla-new",
+                    url="http://hg.test",
+                    access_group=SCM_LEVEL_3,
+                    commit_flags=["VALIDFLAG1", "VALIDFLAG2"],
+                ),
             }
         }
     )

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -99,6 +99,19 @@ def test_commit_message_reviewers_replaced(reviewer_text):
     assert commit_message == (FIRST_LINE, COMMIT_MESSAGE)
 
 
+def test_commit_message_with_flags():
+    reviewers = ["reviewer_one", "reviewer.two"]
+    commit_message = format_commit_message(
+        title="A title.",
+        bug=1,
+        reviewers=reviewers,
+        summary="A summary.",
+        revision_url="http://phabricator.test/D123",
+        flags=["DONTBUILD"],
+    )
+    assert commit_message[0] == FIRST_LINE + " DONTBUILD"
+
+
 @pytest.mark.xfail(strict=True)
 def test_group_reviewers_replaced_with_period_at_end():
     """Test unexpected period after reviewer name.


### PR DESCRIPTION
The API should accept a `flags` parameter when submitting a transplant, and allowed flags should be appended to commit messages.