### PR TITLE
repos: enable landing worker for mozilla-central (bug 1652795)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -338,7 +338,7 @@ def post(data):
         )
     )
 
-    if landing_repo.transplant_locally:
+    if not landing_repo.legacy_transplant:
         with db.session.begin_nested():
             _lock_table_for(db.session, model=LandingJob)
             if (

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -182,6 +182,12 @@ REPO_CONFIG = {
             access_group=SCM_VERSIONCONTROL,
             pull_path="https://autolandhg.devsvcdev.mozaws.net/test-repo",
         ),
+        "m-c": Repo(
+            tree="m-c",
+            url="https://autolandhg.devsvcdev.mozaws.net/local/m-c/",
+            access_group=SCM_VERSIONCONTROL,
+            push_path="ssh://autolandhg.devsvcdev.mozaws.net//local_repos/m-c",
+        ),
     },
     "devsvcprod": {
         "phabricator-qa-stage": Repo(

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -43,9 +43,9 @@ class Repo:
             `url` but with `ssh` protocol.
         pull_path (str): The protocol, hostname, and path to use when cloning or pulling
             from a remote Mercurial repository. Defaults to `url`.
-        transplant_locally (bool): When set to `True`, disables publishing the
-            transplant requests to "Autoland Transplant" and instead queues these
-            requests in the Landing Worker. Defaults to `False`.
+        legacy_transplant (bool): (defunct) When set to `True`, publishes transplant
+            request to "Autoland Transplant" instead of queing the requests in the
+            Landing Worker. Defaults to `False`.
         approval_required (bool): Whether approval is required or not for given repo.
             Note that this is not fully implemented but is included for compatibility.
             Defaults to `False`.
@@ -60,7 +60,7 @@ class Repo:
     push_bookmark: str = ""
     push_path: str = ""
     pull_path: str = ""
-    transplant_locally: bool = False
+    legacy_transplant: bool = False
     approval_required: bool = False
     config_override: dict = None
 
@@ -129,15 +129,13 @@ REPO_CONFIG = {
             tree="test-repo", url="http://hg.test/test-repo", access_group=SCM_LEVEL_1
         ),
         "first-repo": Repo(
-            tree="first-repo",
-            url="http://hg.test/first-repo",
-            access_group=SCM_LEVEL_1,
-            transplant_locally=True,
+            tree="first-repo", url="http://hg.test/first-repo", access_group=SCM_LEVEL_1
         ),
         "second-repo": Repo(
             tree="second-repo",
             url="http://hg.test/second-repo",
             access_group=SCM_LEVEL_1,
+            legacy_transplant=True,
         ),
         "third-repo": Repo(
             tree="third-repo",
@@ -145,7 +143,6 @@ REPO_CONFIG = {
             access_group=SCM_LEVEL_1,
             push_path="ssh://autoland.hg//repos/third-repo",
             pull_path="http://hg.test/third-repo",
-            transplant_locally=True,
         ),
         # Approval is required for the uplift dev repo
         "uplift-target": Repo(
@@ -153,6 +150,7 @@ REPO_CONFIG = {
             url="http://hg.test",  # TODO: fix this? URL is probably incorrect.
             access_group=SCM_LEVEL_1,
             approval_required=True,
+            legacy_transplant=True,
         ),
     },
     "devsvcdev": {
@@ -163,20 +161,19 @@ REPO_CONFIG = {
             access_group=SCM_VERSIONCONTROL,
             push_path="ssh://autolandhg.devsvcdev.mozaws.net//repos/test-repo",
             pull_path="https://autolandhg.devsvcdev.mozaws.net/test-repo",
-            transplant_locally=True,
         ),
         # A repo to test local transplants.
         "first-repo": Repo(
             tree="first-repo",
             url="https://autolandhg.devsvcdev.mozaws.net/first-repo",
             access_group=SCM_VERSIONCONTROL,
-            transplant_locally=True,
         ),
         # A repo to test autoland transplants.
         "second-repo": Repo(
             tree="second-repo",
             url="https://autolandhg.devsvcdev.mozaws.net/second-repo",
             access_group=SCM_VERSIONCONTROL,
+            legacy_transplant=True,
         ),
         # A repo to test different push/pull paths.
         "third-repo": Repo(
@@ -184,7 +181,6 @@ REPO_CONFIG = {
             url="https://autolandhg.devsvcdev.mozaws.net/third-repo",
             access_group=SCM_VERSIONCONTROL,
             pull_path="https://autolandhg.devsvcdev.mozaws.net/test-repo",
-            transplant_locally=True,
         ),
     },
     "devsvcprod": {
@@ -192,38 +188,32 @@ REPO_CONFIG = {
             tree="phabricator-qa-stage",
             url="https://hg.mozilla.org/automation/phabricator-qa-stage",
             access_group=SCM_LEVEL_3,
-            transplant_locally=True,
         ),
         "version-control-tools": Repo(
             tree="version-control-tools",
             url="https://hg.mozilla.org/hgcustom/version-control-tools",
             access_group=SCM_VERSIONCONTROL,
             push_bookmark="@",
-            transplant_locally=True,
         ),
         "build-tools": Repo(
             tree="build-tools",
             url="https://hg.mozilla.org/build/tools/",
             access_group=SCM_LEVEL_3,
-            transplant_locally=True,
         ),
         "ci-admin": Repo(
             tree="ci-admin",
             url="https://hg.mozilla.org/ci/ci-admin",
             access_group=SCM_FIREFOXCI,
-            transplant_locally=True,
         ),
         "ci-configuration": Repo(
             tree="ci-configuration",
             url="https://hg.mozilla.org/ci/ci-configuration",
             access_group=SCM_FIREFOXCI,
-            transplant_locally=True,
         ),
         "fluent-migration": Repo(
             tree="fluent-migration",
             url="https://hg.mozilla.org/l10n/fluent-migration",
             access_group=SCM_L10N_INFRA,
-            transplant_locally=True,
         ),
         "mozilla-central": Repo(
             tree="gecko",
@@ -234,25 +224,19 @@ REPO_CONFIG = {
             tree="comm-central",
             url="https://hg.mozilla.org/comm-central",
             access_group=SCM_LEVEL_3,
-            transplant_locally=True,
         ),
         "nspr": Repo(
             tree="nspr",
             url="https://hg.mozilla.org/projects/nspr",
             access_group=SCM_NSS,
-            transplant_locally=True,
         ),
         "taskgraph": Repo(
             tree="taskgraph",
             url="https://hg.mozilla.org/ci/taskgraph",
             access_group=SCM_LEVEL_3,
-            transplant_locally=True,
         ),
         "nss": Repo(
-            tree="nss",
-            url="https://hg.mozilla.org/projects/nss",
-            access_group=SCM_NSS,
-            transplant_locally=True,
+            tree="nss", url="https://hg.mozilla.org/projects/nss", access_group=SCM_NSS
         ),
     },
 }

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -44,7 +44,7 @@ class Repo:
         pull_path (str): The protocol, hostname, and path to use when cloning or pulling
             from a remote Mercurial repository. Defaults to `url`.
         legacy_transplant (bool): (defunct) When set to `True`, publishes transplant
-            request to "Autoland Transplant" instead of queing the requests in the
+            request to "Autoland Transplant" instead of queueing the requests in the
             Landing Worker. Defaults to `False`.
         approval_required (bool): Whether approval is required or not for given repo.
             Note that this is not fully implemented but is included for compatibility.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,12 +263,14 @@ def mocked_repo_config(mock_repo_config):
                     url="http://hg.test",
                     access_group=SCM_LEVEL_3,
                     approval_required=False,
+                    legacy_transplant=True,
                 ),
                 "mozilla-uplift": Repo(
                     tree="mozilla-uplift",
                     url="http://hg.test/uplift",
                     access_group=SCM_LEVEL_3,
                     approval_required=True,
+                    legacy_transplant=True,
                 ),
             }
         }

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -177,7 +177,7 @@ def test_integrated_execute_job(
         access_group=SCM_LEVEL_3,
         push_path=hg_server,
         pull_path=hg_server,
-        transplant_locally=True,
+        legacy_transplant=False,
     )
     hgrepo = HgRepo(hg_clone.strpath)
     upload_patch(1)

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -587,6 +587,7 @@ def test_integrated_push_bookmark_sent_when_supported_repo(
                     url="http://hg.test",
                     access_group=SCM_LEVEL_3,
                     push_bookmark="@",
+                    legacy_transplant=True,
                 )
             }
         }


### PR DESCRIPTION
This change will enable Landing Worker (and ability to cancel landing jobs) on `mozilla-central`. Note that `mozilla-central` also needs to be added to the `REPOS_TO_LAND` environment variable upon deployment.

Also:

- Rename `transplant_locally` to `legacy_transplant`
- Change default value of `legacy_transplant` to `False` (i.e. a repo will use the landing worker by default)