### PR TITLE
landing worker: refresh enabled repos more frequently (bug 1655546)

### DIFF
--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -144,6 +144,10 @@ class LandingWorker:
         last_job_finished = True
 
         while self.running:
+            # Check if any closed trees reopened since the beginning of this iteration
+            if len(self.enabled_repos) != len(self.applicable_repos):
+                self.refresh_enabled_repos()
+
             if not last_job_finished:
                 logger.info(
                     "Last job did not complete, waiting for {} seconds".format(


### PR DESCRIPTION
In certain cases, the enabled repos are not correctly refreshed which
can cause landing jobs to be stuck in a pending state until the repos
are refreshed. This change forces a recheck periodically whenever the
list of enabled repos does not match the applicable repos.