### PR TITLE
transplants: fixes to DONTBUILD (bug 1661134, 1658019)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -271,12 +271,13 @@ def post(data):
             f"{to_land}, {landing_repo}, {stack_data}"
         )
 
-    invalid_flags = set(flags) - set(landing_repo.commit_flags)
+    allowed_flags = [f[0] for f in landing_repo.commit_flags]
+    invalid_flags = set(flags) - set(allowed_flags)
     if invalid_flags:
         raise ProblemException(
             400,
             "Invalid flags specified",
-            f"Flags must be one or more of {landing_repo.commit_flags}; "
+            f"Flags must be one or more of {allowed_flags}; "
             f"{invalid_flags} provided.",
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -111,7 +111,10 @@ def format_commit_message(
     title = title.strip()
     summary = summary.strip()
 
-    # Append any flags to the title, as needed
+    # Check if any flags are already in the title, and exclude those.
+    flags = [f for f in flags if f not in title] if flags else None
+
+    # Append any flags to the title, as needed.
     if flags:
         title = f"{title} {' '.join(flags)}"
 

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -14,7 +14,7 @@ from landoapi.storage import db
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_GRACE_SECONDS = os.environ.get("DEFAULT_GRACE_SECONDS", 60 * 2)
+DEFAULT_GRACE_SECONDS = int(os.environ.get("DEFAULT_GRACE_SECONDS", 60 * 2))
 
 
 @enum.unique

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -51,8 +51,8 @@ class Repo:
         approval_required (bool): Whether approval is required or not for given repo.
             Note that this is not fully implemented but is included for compatibility.
             Defaults to `False`.
-        commit_flags (bool): A list of supported flags that can be appended to the
-            commit message at landing time (e.g. `["DONTBUILD"]`).
+        commit_flags (list of tuple): A list of supported flags that can be appended to
+            the commit message at landing time (e.g. `[("DONTBUILD", "help text")]`).
         config_override (dict): Parameters to override when loading the Mercurial
             configuration. The keys and values map directly to configuration keys and
             values. Defaults to `None`.
@@ -145,7 +145,16 @@ REPO_CONFIG = {
             url="http://hg.test/first-repo",
             push_path="ssh://autoland.hg//first-repo",
             access_group=SCM_LEVEL_1,
-            commit_flags=["DONTBUILD"],
+            commit_flags=[
+                (
+                    "DONTBUILD",
+                    (
+                        "Should be used only for trivial changes (typo, comment changes"
+                        " documentation changes, etc.) where the risk of introducing a"
+                        " new bug is close to none."
+                    ),
+                )
+            ],
         ),
         "second-repo": Repo(
             tree="second-repo",
@@ -177,7 +186,16 @@ REPO_CONFIG = {
             access_group=SCM_VERSIONCONTROL,
             push_path="ssh://autolandhg.devsvcdev.mozaws.net//repos/test-repo",
             pull_path="https://autolandhg.devsvcdev.mozaws.net/test-repo",
-            commit_flags=["DONTBUILD"],
+            commit_flags=[
+                (
+                    "DONTBUILD",
+                    (
+                        "Should be used only for trivial changes (typo, comment changes"
+                        " documentation changes, etc.) where the risk of introducing a"
+                        " new bug is close to none."
+                    ),
+                )
+            ],
         ),
         # A repo to test local transplants.
         "first-repo": Repo(
@@ -244,7 +262,16 @@ REPO_CONFIG = {
             url="https://hg.mozilla.org/integration/autoland",
             access_group=SCM_LEVEL_3,
             short_name="mozilla-central",
-            commit_flags=["DONTBUILD"],
+            commit_flags=[
+                (
+                    "DONTBUILD",
+                    (
+                        "Should be used only for trivial changes (typo, comment changes"
+                        " documentation changes, etc.) where the risk of introducing a"
+                        " new bug is close to none."
+                    ),
+                )
+            ],
         ),
         "comm-central": Repo(
             tree="comm-central",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,7 +276,7 @@ def mocked_repo_config(mock_repo_config):
                     tree="mozilla-new",
                     url="http://hg.test/new",
                     access_group=SCM_LEVEL_3,
-                    commit_flags=["VALIDFLAG1", "VALIDFLAG2"],
+                    commit_flags=[("VALIDFLAG1", "testing"), ("VALIDFLAG2", "testing")],
                 ),
             }
         }

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -112,6 +112,19 @@ def test_commit_message_with_flags():
     assert commit_message[0] == FIRST_LINE + " DONTBUILD"
 
 
+def test_commit_message_with_flags_does_not_duplicate_flags():
+    reviewers = ["reviewer_one", "reviewer.two"]
+    commit_message = format_commit_message(
+        title="A title. DONTBUILD",
+        bug=1,
+        reviewers=reviewers,
+        summary="A summary.",
+        revision_url="http://phabricator.test/D123",
+        flags=["DONTBUILD"],
+    )
+    assert commit_message[0].count("DONTBUILD") == 1
+
+
 @pytest.mark.xfail(strict=True)
 def test_group_reviewers_replaced_with_period_at_end():
     """Test unexpected period after reviewer name.


### PR DESCRIPTION
commit message: don't duplicate flag if already present (bug 1661134)
transplants: add help text to flags (bug 1658019) 