### PR TITLE
transplants: add support for testing policy warnings (bug 1666309)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -21,6 +21,8 @@ from landoapi.projects import (
     get_checkin_project_phid,
     get_sec_approval_project_phid,
     get_secure_project_phid,
+    get_testing_tag_project_phids,
+    get_testing_policy_phid,
     get_relman_group_phid,
     project_search,
 )
@@ -205,6 +207,8 @@ def _assess_transplant_request(phab, landing_path):
         users,
         projects,
         get_secure_project_phid(phab),
+        get_testing_tag_project_phids(phab),
+        get_testing_policy_phid(phab),
     )
     return (assessment, to_land, landing_repo, stack_data)
 

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -3,8 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 
+from typing import Optional, List
+
 from landoapi.cache import cache
-from landoapi.phabricator import result_list_to_phid_dict
+from landoapi.phabricator import result_list_to_phid_dict, PhabricatorClient
 
 logger = logging.getLogger(__name__)
 
@@ -89,27 +91,15 @@ def get_project_phid(project_slug, phabricator, allow_empty_result=True):
 
 
 @cache.cached(key_prefix=SEC_PROJ_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)
-def get_secure_project_phid(phabricator):
+def get_secure_project_phid(phabricator: PhabricatorClient) -> Optional[str]:
     """Return a phid for the project indicating revision security.
-
-    Args:
-        phabricator: A PhabricatorClient instance.
-
-    Returns:
-        A string phid if the project is found, otherwise None.
     """
     return get_project_phid(SEC_PROJ_SLUG, phabricator)
 
 
 @cache.cached(key_prefix=CHECKIN_PROJ_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)
-def get_checkin_project_phid(phabricator):
+def get_checkin_project_phid(phabricator: PhabricatorClient) -> Optional[str]:
     """Return a phid for the project indicating check-in is needed.
-
-    Args:
-        phabricator: A PhabricatorClient instance.
-
-    Returns:
-        A string phid if the project is found, otherwise None.
     """
     return get_project_phid(CHECKIN_PROJ_SLUG, phabricator)
 
@@ -117,34 +107,24 @@ def get_checkin_project_phid(phabricator):
 @cache.cached(
     key_prefix=TESTING_POLICY_PROJ_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT
 )
-def get_testing_policy_phid(phabricator):
+def get_testing_policy_phid(phabricator: PhabricatorClient) -> Optional[str]:
     """Return a phid for the project indicating testing policy.
-
-    Args:
-        phabricator: A PhabricatorClient instance.
-
-    Returns:
-        A string phid if the project is found, otherwise None.
     """
     return get_project_phid(TESTING_POLICY_PROJ_SLUG, phabricator)
 
 
 @cache.cached(key_prefix=TESTING_TAGS_PROJ_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)
-def get_testing_tag_project_phids(phabricator):
+def get_testing_tag_project_phids(
+    phabricator: PhabricatorClient
+) -> Optional[List[str]]:
     """Return phids for the testing tag projects.
-
-    Args:
-        phabricator: A PhabricatorClient instance.
-
-    Returns:
-        list of str: A list of phids if the projects are found, otherwise None.
     """
     tags = [get_project_phid(slug, phabricator) for slug in TESTING_TAG_PROJ_SLUGS]
     return [t for t in tags if t is not None]
 
 
 @cache.cached(key_prefix=SEC_APPROVAL_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)
-def get_sec_approval_project_phid(phabricator):
+def get_sec_approval_project_phid(phabricator: PhabricatorClient) -> Optional[str]:
     """Return a phid for the sec-approval group's project.
 
     Args:
@@ -157,13 +137,7 @@ def get_sec_approval_project_phid(phabricator):
 
 
 @cache.cached(key_prefix=RELMAN_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)
-def get_relman_group_phid(phabricator):
+def get_relman_group_phid(phabricator: PhabricatorClient) -> Optional[str]:
     """Return a phid for the relman group's project.
-
-    Args:
-        phabricator: A PhabricatorClient instance.
-
-    Returns:
-        A string phid if the project is found, otherwise None.
     """
     return get_project_phid(RELMAN_PROJECT_SLUG, phabricator)

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -14,6 +14,22 @@ SEC_PROJ_SLUG = "secure-revision"
 SEC_PROJ_CACHE_KEY = "secure-project-phid"
 CHECKIN_PROJ_SLUG = "check-in_needed"
 CHECKIN_PROJ_CACHE_KEY = "checkin-project-phid"
+
+# Testing tag slugs. Revisions need one of these tags to remove the respective warnings.
+TESTING_TAG_PROJ_SLUGS = (
+    "testing-approved",
+    "testing-exception-elsewhere",
+    "testing-exception-other",
+    "testing-exception-ui",
+    "testing-exception-unchanged",
+)
+
+TESTING_TAGS_PROJ_CACHE_KEY = "testing-tag-phids"
+
+# A repo with a "testing-policy" project will have testing policy warnings enabled.
+TESTING_POLICY_PROJ_SLUG = "testing-policy"
+TESTING_POLICY_PROJ_CACHE_KEY = "testing-policy-phid"
+
 # The name of the Phabricator project containing members of the Secure
 # Bug Approval Process.
 # See https://wiki.mozilla.org/Security/Bug_Approval_Process.
@@ -96,6 +112,35 @@ def get_checkin_project_phid(phabricator):
         A string phid if the project is found, otherwise None.
     """
     return get_project_phid(CHECKIN_PROJ_SLUG, phabricator)
+
+
+@cache.cached(
+    key_prefix=TESTING_POLICY_PROJ_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT
+)
+def get_testing_policy_phid(phabricator):
+    """Return a phid for the project indicating testing policy.
+
+    Args:
+        phabricator: A PhabricatorClient instance.
+
+    Returns:
+        A string phid if the project is found, otherwise None.
+    """
+    return get_project_phid(TESTING_POLICY_PROJ_SLUG, phabricator)
+
+
+@cache.cached(key_prefix=TESTING_TAGS_PROJ_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)
+def get_testing_tag_project_phids(phabricator):
+    """Return phids for the testing tag projects.
+
+    Args:
+        phabricator: A PhabricatorClient instance.
+
+    Returns:
+        list of str: A list of phids if the projects are found, otherwise None.
+    """
+    tags = [get_project_phid(slug, phabricator) for slug in TESTING_TAG_PROJ_SLUGS]
+    return [t for t in tags if t is not None]
 
 
 @cache.cached(key_prefix=SEC_APPROVAL_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -236,8 +236,14 @@ class PhabricatorDouble:
             "hashes": [],
             "bugzilla.bug-id": bug_id,
             "repositoryPHID": repo["phid"] if repo is not None else None,
+            "fields": {"repositoryPHID": repo["phid"] if repo is not None else None},
             "sourcePath": None,
+            # projectPHIDs is left for backwards compatibility for older tests, though
+            # it appears to no longer be in the response from the Phabricator API.
             "projectPHIDs": [project["phid"] for project in projects],
+            "attachments": {
+                "projects": {"projectPHIDs": [project["phid"] for project in projects]}
+            },
         }
 
         for rev in depends_on:
@@ -417,7 +423,8 @@ class PhabricatorDouble:
 
         return diff
 
-    def repo(self, *, name="mozilla-central"):
+    def repo(self, *, name="mozilla-central", projects=None):
+        projects = projects or []
         repos = [r for r in self._repos if r["name"] == name]
         if repos:
             return repos[0]
@@ -440,6 +447,9 @@ class PhabricatorDouble:
             "dateCreated": 1502986064,
             "dateModified": 1505659447,
             "policy": {"view": "public", "edit": "admin", "diffusion.push": "no-one"},
+            "attachments": {
+                "projects": {"projectPHIDs": [project["phid"] for project in projects]}
+            },
         }
 
         self._repos.append(repo)

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -3,14 +3,17 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
+from unittest.mock import MagicMock
 
 from landoapi.phabricator import RevisionStatus, ReviewerStatus
 from landoapi.repos import get_repos_for_env
+
 from landoapi.revisions import (
     check_author_planned_changes,
     check_diff_author_is_known,
     check_relman_approval,
     revision_is_secure,
+    revision_needs_testing_tag,
 )
 
 pytestmark = pytest.mark.usefixtures("docker_env_vars")
@@ -143,3 +146,45 @@ def test_relman_approval_status(status, phabdouble):
             output
             == "The release-managers group did not accept that stack: you need to wait for a group approval from release-managers, or request a new review."  # noqa
         )
+
+
+def test_revision_does_not_need_testing_tag(phabdouble, monkeypatch):
+    testing_tag_projects = [{"phid": "testing-tag-phid"}]
+    testing_policy_project = {"phid": "testing-policy-phid"}
+    repo = phabdouble.repo(projects=[testing_policy_project])
+    revision = phabdouble.revision(projects=testing_tag_projects, repo=repo)
+    mock_get_phabricator_repo = MagicMock()
+    mock_get_phabricator_repo.return_value = repo
+    monkeypatch.setattr(
+        "landoapi.revisions.get_phabricator_repo", mock_get_phabricator_repo
+    )
+    assert not revision_needs_testing_tag(
+        revision, ["testing-tag-phid"], "testing-policy-phid"
+    )
+
+
+def test_revision_needs_testing_tag(phabdouble, monkeypatch):
+    testing_policy_project = {"phid": "testing-policy-phid"}
+    repo = phabdouble.repo(projects=[testing_policy_project])
+    revision = phabdouble.revision(projects=[], repo=repo)
+    mock_get_phabricator_repo = MagicMock()
+    mock_get_phabricator_repo.return_value = repo
+    monkeypatch.setattr(
+        "landoapi.revisions.get_phabricator_repo", mock_get_phabricator_repo
+    )
+    assert revision_needs_testing_tag(
+        revision, ["testing-tag-phid"], "testing-policy-phid"
+    )
+
+
+def test_repo_does_not_have_testing_policy(phabdouble, monkeypatch):
+    repo = phabdouble.repo(projects=[])
+    revision = phabdouble.revision(projects=[], repo=repo)
+    mock_get_phabricator_repo = MagicMock()
+    mock_get_phabricator_repo.return_value = repo
+    monkeypatch.setattr(
+        "landoapi.revisions.get_phabricator_repo", mock_get_phabricator_repo
+    )
+    assert not revision_needs_testing_tag(
+        revision, ["testing-tag-phid"], "testing-policy-phid"
+    )


### PR DESCRIPTION
Adds support for testing policy tags by:
- Checking if a repository has a `testing-policy` project associated with it, thus implying that said repo should enforce testing policy tags on all revisions
- Checking if a particular revision has a testing policy tag, and if not, adds a warning to the revision