### PR TITLE
landing worker: fix failed paths parsing (bug 1696396)

### DIFF
--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -230,6 +230,8 @@ class LandingWorker:
         # TODO: capture reason for patch failure, e.g. deleting non-existing file, or
         # adding a pre-existing file, etc...
         reject_paths = rejs_re.findall(exception)
+
+        # Collect all failed paths by removing `.rej` extension.
         failed_paths = [path[:-4] for path in reject_paths]
 
         return failed_paths, reject_paths
@@ -340,6 +342,8 @@ class LandingWorker:
                                     reject["content"] = f.read()
                             except Exception as e:
                                 logger.exception(e)
+                            # Use actual path of file to store reject data, by removing
+                            # `.rej` extension.
                             breakdown["reject_paths"][r[:-4]] = reject
 
                         message = (

--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -340,7 +340,7 @@ class LandingWorker:
                                     reject["content"] = f.read()
                             except Exception as e:
                                 logger.exception(e)
-                            breakdown["reject_paths"][r[:-3]] = reject
+                            breakdown["reject_paths"][r[:-4]] = reject
 
                         message = (
                             f"Problem while applying patch in revision {revision_id}:\n\n"

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -319,6 +319,8 @@ def test_landing_worker__extract_error_data():
     unable to find 'abc/def' for patching
     (use '--prefix' to apply patch relative to the current directory)
     1 out of 1 hunks FAILED -- saving rejects to file abc/def.rej
+    patching file browser/locales/en-US/browser/browserContext.ftl
+    Hunk #1 succeeded at 300 with fuzz 2 (offset -4 lines).
     abort: patch failed to apply"""
     )
 


### PR DESCRIPTION
- do not fetch failed paths form raw output
    - look at .rej paths instead
- trim last 4 characters instead of using .rstrip to get file path