### PR TITLE
Bug 1749754: add a landing warning to check if a patch has `WIP:` in the title

### DIFF
--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -295,6 +295,13 @@ def warning_diff_warning(*, revision, diff, **kwargs):
         return [w.data for w in warnings]
 
 
+@RevisionWarningCheck(7, "Revision is marked as WIP.")
+def warning_wip_commit_message(*, revision, **kwargs):
+    title = PhabricatorClient.expect(revision, "fields", "title")
+    if title.lower().startswith("wip:"):
+        return "This revision is marked as a WIP. Please remove `WIP:` before landing."
+
+
 def user_block_no_auth0_email(*, auth0_user, **kwargs):
     """Check the user has a proper auth0 email."""
     return (
@@ -338,6 +345,7 @@ def check_landing_warnings(
         warning_revision_secure,
         warning_revision_missing_testing_tag,
         warning_diff_warning,
+        warning_wip_commit_message,
     ],
 ):
     assessment = TransplantAssessment()

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -21,6 +21,7 @@ from landoapi.transplants import (
     warning_previously_landed,
     warning_reviews_not_current,
     warning_revision_secure,
+    warning_wip_commit_message,
 )
 
 
@@ -869,6 +870,18 @@ def test_integrated_transplant_sec_approval_group_is_excluded_from_reviewers_lis
     )
     patch_text = patch.get()["Body"].read().decode()
     assert sec_approval_project["name"] not in patch_text
+
+
+def test_warning_wip_commit_message(phabdouble):
+    revision = phabdouble.api_object_for(
+        phabdouble.revision(
+            title="WIP: Bug 123: test something r?reviewer",
+            status=RevisionStatus.ACCEPTED,
+        ),
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+    )
+
+    assert warning_wip_commit_message(revision=revision) is not None
 
 
 def test_display_branch_head():


### PR DESCRIPTION
Adds a revision warning to assert a revision does not have `WIP:`
as the beginning of it's revision title. The presence of `WIP:`
indicates a work-in-progress revision and should be scrubbed before
landing by the user.

We could follow up with some code to automatically scrub the `WIP`
text from the commit message, but this is a good start for now.
