### PR TITLE
Bug 1754801: compare enum equality with `==` consistently

### DIFF
--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -44,8 +44,8 @@ def calculate_review_extra_state(
         }
     """
     other_diff = for_diff_phid != reviewer_diff_phid and reviewer_status.diff_specific
-    blocks_landing = reviewer_status is ReviewerStatus.BLOCKING or (
-        reviewer_status is ReviewerStatus.REJECTED and not other_diff
+    blocks_landing = reviewer_status == ReviewerStatus.BLOCKING or (
+        reviewer_status == ReviewerStatus.REJECTED and not other_diff
     )
     return {"for_other_diff": other_diff, "blocking_landing": blocks_landing}
 
@@ -166,7 +166,7 @@ def reviewers_for_commit_message(
     return [
         reviewer_identity(phid, users, projects).identifier
         for phid, r in reviewers.items()
-        if (phid != sec_approval_phid and r["status"] is ReviewerStatus.ACCEPTED)
+        if (phid != sec_approval_phid and r["status"] == ReviewerStatus.ACCEPTED)
     ]
 
 

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -248,7 +248,7 @@ def warning_reviews_not_current(*, diff, reviewers, **kwargs):
             diff["phid"], r["status"], r["diffPHID"], r["voidedPHID"]
         )
 
-        if r["status"] is ReviewerStatus.ACCEPTED and not extra["for_other_diff"]:
+        if r["status"] == ReviewerStatus.ACCEPTED and not extra["for_other_diff"]:
             return None
 
     return "Has no accepted review on the current diff."

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -279,7 +279,7 @@ def test_integrated_execute_job(
     worker = LandingWorker(sleep_seconds=0.01)
 
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
-    assert job.status is LandingJobStatus.LANDED
+    assert job.status == LandingJobStatus.LANDED
     assert len(job.landed_commit_id) == 40
 
 
@@ -310,7 +310,7 @@ def test_lose_push_race(
     worker = LandingWorker(sleep_seconds=0)
 
     assert not worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
-    assert job.status is LandingJobStatus.DEFERRED
+    assert job.status == LandingJobStatus.DEFERRED
 
 
 def test_failed_landing_job_notification(
@@ -356,7 +356,7 @@ def test_failed_landing_job_notification(
     )
 
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
-    assert job.status is LandingJobStatus.FAILED
+    assert job.status == LandingJobStatus.FAILED
     assert mock_notify.call_count == 1
 
 
@@ -449,7 +449,7 @@ def test_format_patch_success_unchanged(
 
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
     assert (
-        job.status is LandingJobStatus.LANDED
+        job.status == LandingJobStatus.LANDED
     ), "Successful landing did not set correct status"
     assert job.formatted_replacements is None
 
@@ -498,7 +498,7 @@ def test_format_patch_success_changed(
 
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
     assert (
-        job.status is LandingJobStatus.LANDED
+        job.status == LandingJobStatus.LANDED
     ), "Successful landing did not set correct status"
     assert (
         job.formatted_replacements == formatted_replacements
@@ -581,7 +581,7 @@ def test_format_patch_fail(
     )
 
     assert not worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
-    assert job.status is LandingJobStatus.FAILED
+    assert job.status == LandingJobStatus.FAILED
     assert "no fixes will be applied" in job.error
     assert mock_notify.call_count == 1
 
@@ -634,5 +634,5 @@ def test_format_patch_no_landoini(
     )
 
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
-    assert job.status is LandingJobStatus.LANDED
+    assert job.status == LandingJobStatus.LANDED
     assert mock_notify.call_count == 0


### PR DESCRIPTION
Lando makes use of enums to compare allowed values,
and is inconsistent about using `==` or `is` to
make these comparisons. Convert uses of `is` enum
comparisons to `==` wholesale.

Checked by doing a global search for all `@enum`
in the repo, then searching for all instances of
each class type and ensuring comparisons are made
with `==`.
