### PR TITLE
treestatus: consider "approval required" status as open for landing (Bug 1756036)

### DIFF
--- a/landoapi/treestatus.py
+++ b/landoapi/treestatus.py
@@ -16,8 +16,16 @@ class TreeStatus:
 
     DEFAULT_URL = "https://treestatus.mozilla-releng.net"
 
+    # A repo is considered open for landing when either of these
+    # statuses are present.
+
+    # For the "approval required" status Lando will enforce the appropriate
+    # Phabricator group review for approval (`release-managers`) and the hg
+    # hook will enforce `a=<reviewer>` is present in the commit message.
+    OPEN_STATUSES = {"approval required", "open"}
+
     def __init__(self, *, url=None, session=None):
-        self.url = url if url is not None else self.DEFAULT_URL
+        self.url = url if url is not None else TreeStatus.DEFAULT_URL
         self.url = self.url if self.url[-1] == "/" else self.url + "/"
         self.session = session or self.create_session()
 
@@ -35,7 +43,7 @@ class TreeStatus:
             return True
 
         try:
-            return resp["result"]["status"] == "open"
+            return resp["result"]["status"] in TreeStatus.OPEN_STATUSES
         except KeyError as exc:
             raise TreeStatusCommunicationException(
                 "Tree status response did not contain expected data"

--- a/tests/test_treestatus.py
+++ b/tests/test_treestatus.py
@@ -110,4 +110,4 @@ def test_is_open_for_closed_tree(treestatusdouble):
 def test_is_open_for_approval_required_tree(treestatusdouble):
     ts = treestatusdouble.get_treestatus_client()
     treestatusdouble.set_tree("mozilla-central", status="approval required")
-    assert not ts.is_open("mozilla-central")
+    assert ts.is_open("mozilla-central")


### PR DESCRIPTION
Within the new uplift workflow, repositories on Lando with
"approval required" status should be considered open for landing.
The approval is checked in Lando by asserting `release-managers`
review on the revision and the hg hook asserts `a=<reviewer>` is
present in the first line of the commit message. Thus we can
consider an "approval required" repo as landable and enabled.
