### PR TITLE
commit-message: expand instances of review specifiers (Bug 1756048)

### DIFF
--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -31,9 +31,8 @@ BUG_RE = re.compile(
 # "bug" syntax like "bug X" or "b=".
 BUG_CONSERVATIVE_RE = re.compile(r"""((?:bug|b=)(?:\s*)(\d+)(?=\b))""", re.I | re.X)
 
-SPECIFIER = r"(?:r|a|sr|rs|ui-r)[=?]"
-R_SPECIFIER = r"\br[=?]"
-R_SPECIFIER_RE = re.compile(R_SPECIFIER)
+SPECIFIER = r"\b(?:r|a|sr|rs|ui-r)[=?]"
+SPECIFIER_RE = re.compile(SPECIFIER)
 
 LIST = r"[;,\/\\]\s*"
 
@@ -156,7 +155,7 @@ def replace_reviewers(
     commit_summary = commit_description_lines.pop(0)
     commit_description = "\n".join(commit_description_lines)
 
-    if not R_SPECIFIER_RE.search(commit_summary):
+    if not SPECIFIER_RE.search(commit_summary):
         commit_summary += " " + reviewers_str
     else:
         # replace the first r? with the reviewer list, and all subsequent
@@ -165,7 +164,7 @@ def replace_reviewers(
         d = {"first": True}
 
         def replace_first_reviewer(matchobj):
-            if R_SPECIFIER_RE.match(matchobj.group(2)):
+            if SPECIFIER_RE.match(matchobj.group(2)):
                 if d["first"]:
                     d["first"] = False
                     return matchobj.group(1) + reviewers_str

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -76,6 +76,11 @@ def test_commit_message_blocking_reviewers_requested(reviewer_text):
     "reviewer_text",
     [
         "r?bogus",
+        "a=bogus",
+        "a=bogus r?bogus",
+        "a=bogus r=bogus",
+        "r?bogus a=bogus",
+        "r=bogus a=bogus",
         "r?#group1",
         "r?#group1, #group2",
         "r?reviewer_one,#group1",


### PR DESCRIPTION
Remove the conservative `R_SPECIFIER` and replace with `SPECIFIER`
everywhere. This expands the values used for review specifiers
to catch and scrub `a=` and others when landing code.