### PR TITLE
approvals: only rewrite RelMan reviews as `a=` for approval required repositories (Bug 1755932)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -347,9 +347,12 @@ def post(data):
         )
 
         # Find RelMan reviews for rewriting to `a=<reviewer>`.
-        accepted_reviewers, approval_reviewers = approvals_for_commit_message(
-            reviewers, users, projects, relman_phids, accepted_reviewers
-        )
+        if landing_repo.approval_required:
+            accepted_reviewers, approval_reviewers = approvals_for_commit_message(
+                reviewers, users, projects, relman_phids, accepted_reviewers
+            )
+        else:
+            approval_reviewers = []
 
         secure = revision_is_secure(revision, secure_project_phid)
         commit_description = find_title_and_summary_for_landing(phab, revision, secure)

--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -186,10 +186,12 @@ def approvals_for_commit_message(
         reviewers: Dict of {reviewer_phid: reviewer_data}
         users: List of Phabricator Users that were involved in the revision.
         projects: List of Phabricator Projects that were involved in the revision.
+        relman_phids: List of Phabricator users in the `release-managers` group.
         sec_approval_phid: The PHID string of the sec-approval project.
 
     Returns:
-        A list of strings.
+        A tuple of lists of strings, representing `r=` reviewers and `a=` approvers
+        respectively.
     """
     # Approvals are reviews where the user is in the `release-managers` group.
     approvals = [

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -61,8 +61,9 @@ def test_check_author_planned_changes_changes_planned(phabdouble):
 def test_secure_api_flag_on_public_revision_is_false(
     db, client, phabdouble, release_management_project
 ):
+    repo = phabdouble.repo(name="test-repo")
     public_project = phabdouble.project("public")
-    revision = phabdouble.revision(projects=[public_project])
+    revision = phabdouble.revision(projects=[public_project], repo=repo)
 
     response = client.get("/stacks/D{}".format(revision["id"]))
 
@@ -74,7 +75,8 @@ def test_secure_api_flag_on_public_revision_is_false(
 def test_secure_api_flag_on_secure_revision_is_true(
     db, client, phabdouble, secure_project, release_management_project
 ):
-    revision = phabdouble.revision(projects=[secure_project])
+    repo = phabdouble.repo(name="test-repo")
+    revision = phabdouble.revision(projects=[secure_project], repo=repo)
 
     response = client.get("/stacks/D{}".format(revision["id"]))
 


### PR DESCRIPTION
Fixes a regression caused by #180 where all RelMan reviews are
rewritten from `r=reviewer` to `a=reviewer`. This should only
occur on an uplift repository, so we amend usages of
`approvals_for_commit_message` to only apply when this flag is
set.

Some of the secure revision tests fail after this change due to
a missing repository tagged on the revision so we add a repo to
these tests.
