### PR TITLE
repos: fix typing issue for `repos.commit_flags`

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -347,9 +347,12 @@ def post(data):
         )
 
         # Find RelMan reviews for rewriting to `a=<reviewer>`.
-        accepted_reviewers, approval_reviewers = approvals_for_commit_message(
-            reviewers, users, projects, relman_phids, accepted_reviewers
-        )
+        if landing_repo.approval_required:
+            accepted_reviewers, approval_reviewers = approvals_for_commit_message(
+                reviewers, users, projects, relman_phids, accepted_reviewers
+            )
+        else:
+            approval_reviewers = []
 
         secure = revision_is_secure(revision, secure_project_phid)
         commit_description = find_title_and_summary_for_landing(phab, revision, secure)

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -6,7 +6,10 @@ import logging
 import pathlib
 import urllib
 from collections import namedtuple
-from dataclasses import dataclass
+from dataclasses import (
+    dataclass,
+    field,
+)
 
 from landoapi.systems import Subsystem
 
@@ -67,8 +70,8 @@ class Repo:
     short_name: str = ""
     legacy_transplant: bool = False
     approval_required: bool = False
-    commit_flags: list = None
-    config_override: dict = None
+    commit_flags: list[tuple[str, str]] = field(default_factory=list)
+    config_override: dict = field(default_factory=dict)
 
     def __post_init__(self):
         """Set defaults based on initial values.
@@ -82,18 +85,17 @@ class Repo:
             if not self.pull_path:
                 self.pull_path = self.url
 
-        if not self.commit_flags:
-            self.commit_flags = []
-
         if not self.short_name:
             self.short_name = self.tree
 
     @property
     def autoformat_enabled(self) -> bool:
         """Return `True` if formatting is enabled for the repo."""
-        return self.config_override is not None and any(
-            config.startswith("fix") for config in self.config_override.keys()
-        )
+        if not self.config_override:
+            # Empty config override always indicates no autoformat.
+            return False
+
+        return any(config.startswith("fix") for config in self.config_override.keys())
 
 
 SCM_ALLOW_DIRECT_PUSH = AccessGroup(

--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -186,10 +186,12 @@ def approvals_for_commit_message(
         reviewers: Dict of {reviewer_phid: reviewer_data}
         users: List of Phabricator Users that were involved in the revision.
         projects: List of Phabricator Projects that were involved in the revision.
+        relman_phids: List of Phabricator users in the `release-managers` group.
         sec_approval_phid: The PHID string of the sec-approval project.
 
     Returns:
-        A list of strings.
+        A tuple of lists of strings, representing `r=` reviewers and `a=` approvers
+        respectively.
     """
     # Approvals are reviews where the user is in the `release-managers` group.
     approvals = [

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -61,8 +61,9 @@ def test_check_author_planned_changes_changes_planned(phabdouble):
 def test_secure_api_flag_on_public_revision_is_false(
     db, client, phabdouble, release_management_project
 ):
+    repo = phabdouble.repo(name="test-repo")
     public_project = phabdouble.project("public")
-    revision = phabdouble.revision(projects=[public_project])
+    revision = phabdouble.revision(projects=[public_project], repo=repo)
 
     response = client.get("/stacks/D{}".format(revision["id"]))
 
@@ -74,7 +75,8 @@ def test_secure_api_flag_on_public_revision_is_false(
 def test_secure_api_flag_on_secure_revision_is_true(
     db, client, phabdouble, secure_project, release_management_project
 ):
-    revision = phabdouble.revision(projects=[secure_project])
+    repo = phabdouble.repo(name="test-repo")
+    revision = phabdouble.revision(projects=[secure_project], repo=repo)
 
     response = client.get("/stacks/D{}".format(revision["id"]))
 


### PR DESCRIPTION
- approvals: only rewrite RelMan reviews as `a=` for approval required repositories (Bug 1755932)
- repos: fix typing issue for `repos.commit_flags`
