### PR TITLE
hgexports: clarify `PatchHelper.header()` has type `Optional[str]` (Bug 1759890)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -351,10 +351,19 @@ class HgRepo:
 
             # Commit using the extracted date, user, and commit desc.
             # --landing_system is provided by the set_landing_system hgext.
+            date = patch_helper.header("Date")
+            user = patch_helper.header("User")
+
+            if not user:
+                raise ValueError("Missing `User` header!")
+
+            if not date:
+                raise ValueError("Missing `Date` header!")
+
             self.run_hg(
                 ["commit"]
-                + ["--date", patch_helper.header("Date")]
-                + ["--user", patch_helper.header("User")]
+                + ["--date", date]
+                + ["--user", user]
                 + ["--landing_system", "lando"]
                 + ["--logfile", f_msg.name]
             )

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -3,6 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import re
 
+from typing import (
+    Optional,
+)
+
 
 HEADER_NAMES = (
     b"User",
@@ -113,7 +117,7 @@ class PatchHelper(object):
         finally:
             self.patch.seek(0)
 
-    def header(self, name):
+    def header(self, name) -> Optional[str]:
         """Returns value of the specified header, or None if missing."""
         name = name.encode("utf-8") if isinstance(name, str) else name
         return self.headers.get(name.lower())


### PR DESCRIPTION
Set the concrete `Optional[str]` type for `PatchHelper.header`
and add a `None` check where one is required.
