### PR TITLE
ci: move convenience images to `cimg` Docker namespace (Bug 1762457)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
     docker:
       # Use the python image, all we really care about is the preinstalled
       # tools in a circleci image.
-      - image: circleci/python
+      - image: cimg/python:3.9
     steps:
       - setup_remote_docker
       - checkout


### PR DESCRIPTION
`circleci/` convenience images are deprecated in favour of the
`cimg/` namespace. Switch to them, and use the `3.9` tagged image
while we are here.
