### PR TITLE
uplift: add bugherder functionality when landing to uplift repo (Bug 1773315)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     ports:
       - "8888:8888"
     environment:
+      - BMO_URL=https://bugzilla-dev.allizom.org/
       - PHABRICATOR_URL=https://phabricator-dev.allizom.org/
       - PHABRICATOR_ADMIN_API_KEY=api-0123456789012345678901234567
       - PHABRICATOR_UNPRIVILEGED_API_KEY=api-0123456789012345678901234567

--- a/landoapi/app.py
+++ b/landoapi/app.py
@@ -66,6 +66,7 @@ def load_config():
     config_keys = (
         "AWS_ACCESS_KEY",
         "AWS_SECRET_KEY",
+        "BMO_URL",
         "CACHE_REDIS_DB",
         "CACHE_REDIS_HOST",
         "CACHE_REDIS_PASSWORD",

--- a/landoapi/notifications.py
+++ b/landoapi/notifications.py
@@ -5,7 +5,10 @@ import logging
 
 import kombu
 
-from landoapi.tasks import send_landing_failure_email
+from landoapi.tasks import (
+    send_bug_update_failure_email,
+    send_landing_failure_email,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +29,46 @@ def notify_user_of_landing_failure(email, revision, error, request_id):
     """
     try:
         return send_landing_failure_email.apply_async(
+            (email, revision, error),
+            retry=True,
+            # This policy will result in 3 connection retries if the job queue
+            # is down. The current web request's response will be delayed 600ms
+            # with retries before Kombu gives up and raises an exception.
+            retry_policy={
+                "max_retries": 3,
+                "interval_start": 0,
+                "interval_step": 0.2,
+                "interval_max": 0.2,
+            },
+        )
+    except kombu.exceptions.OperationalError as e:
+        logger.error(
+            f"No notifications were sent for request {request_id} to "
+            f"address {email} because of an exception connecting "
+            f"to the Celery job system. Reason: {e} "
+        )
+        # Let the exception bubble up to any callers.  If the caller was an API call
+        # from the Transplant service then the HTTP error code will cause the Transplant
+        # service to wait and retry the request.
+        raise
+
+
+def notify_user_of_bug_update_failure(email, revision, error, request_id):
+    """Send out user notifications that a bug update failed.
+
+    Args:
+        email (str): Receipent's email address (e.g. `requester_email`.)
+        revision (str): The revision associated with the bug update failure.
+        error (str): The text of the error associated with the bug update failure.
+        request_id (int): A unique identifier identifying either a legacy request ID or
+            a LandingJob ID.
+
+    Raises:
+        kombu.exceptions.OperationalError if there is a problem connecting to the Celery
+        job queue.
+    """
+    try:
+        return send_bug_update_failure_email.apply_async(
             (email, revision, error),
             retry=True,
             # This policy will result in 3 connection retries if the job queue

--- a/landoapi/tasks.py
+++ b/landoapi/tasks.py
@@ -70,6 +70,61 @@ def send_landing_failure_email(recipient_email: str, revision_id: str, error_msg
 
 
 @celery.task(
+    # Auto-retry for errors from the SMTP socket connection. Don't log
+    # stack traces.  All other exceptions will log a stack trace and cause an
+    # immediate job failure without retrying.
+    autoretry_for=(IOError, smtplib.SMTPException, ssl.SSLError),
+    # Seconds to wait between retries.
+    default_retry_delay=60,
+    # Retry sending the notification for three days.  This is the same effort
+    # that SMTP servers use for their outbound mail queues.
+    max_retries=60 * 24 * 3,
+    # Don't store the success or failure results.
+    ignore_result=True,
+    # Don't ack jobs until the job is complete. This should only come up if a worker
+    # dies suddenly in the middle of an email job.  If it does die then it is possible
+    # for the user to get two emails (harmless), which is better than them receiving
+    # no emails.
+    acks_late=True,
+)
+def send_bug_update_failure_email(
+    recipient_email: str, revision_id: str, error_msg: str
+):
+    """Tell a user that the Transplant service couldn't land their code.
+
+    Args:
+        recipient_email: The email of the user receiving the failure notification.
+        revision_id: The Phabricator Revision ID that failed to land. e.g. D12345
+        error_msg: The error message returned by the Transplant service.
+    """
+    if smtp.suppressed:
+        logger.warning(
+            f"Email sending suppressed: application config has disabled "
+            f"all mail sending (recipient was: {recipient_email})"
+        )
+        return
+
+    if not smtp.recipient_allowed(recipient_email):
+        logger.info(
+            f"Email sending suppressed: recipient {recipient_email} not whitelisted"
+        )
+        return
+
+    with smtp.connection() as c:
+        c.send_message(
+            make_failure_email(
+                smtp.default_from,
+                recipient_email,
+                revision_id,
+                error_msg,
+                current_app.config["LANDO_UI_URL"],
+            )
+        )
+
+    logger.info(f"Notification email sent to {recipient_email}")
+
+
+@celery.task(
     autoretry_for=(IOError, PhabricatorCommunicationException),
     default_retry_delay=20,
     max_retries=3 * 20,  # 20 minutes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ def docker_env_vars(versionfile, monkeypatch):
     monkeypatch.setenv(
         "PHABRICATOR_UNPRIVILEGED_API_KEY", "api-thiskeymustbe32characterslen"
     )
+    monkeypatch.setenv("BMO_URL", "http://bmo.test")
     monkeypatch.setenv("TRANSPLANT_URL", "http://autoland.test")
     monkeypatch.setenv("TRANSPLANT_API_KEY", "someapikey")
     monkeypatch.setenv("TRANSPLANT_USERNAME", "autoland")

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from landoapi.phabricator import PhabricatorClient
+from landoapi.uplift import create_uplift_bug_update_payload
 
 
 def test_uplift_creation(
@@ -135,3 +136,30 @@ def test_approval_creation(
     assert len(phabdouble._revisions) == 1
     new_rev = phabdouble._revisions[0]
     assert new_rev["title"] == "my test revision title"
+
+
+def test_create_uplift_bug_update_payload():
+    bug = {
+        "whiteboard": "[checkin-needed-beta]",
+        "keywords": [],
+    }
+    payload = create_uplift_bug_update_payload(bug)
+
+    assert (
+        payload["whiteboard"] == ""
+    ), "checkin-needed flag should be removed from whiteboard."
+    assert payload["status"] == "RESOLVED", "Bug status should be set to RESOLVED."
+    assert payload["resolution"] == "FIXED", "Bug resolution should be set to FIXED."
+
+    bug = {
+        "whiteboard": "[checkin-needed-beta]",
+        "keywords": ["leave-open"],
+    }
+    payload = create_uplift_bug_update_payload(bug)
+
+    assert (
+        "status" not in payload
+    ), "Status should not have been set with `leave-open` keyword on bug."
+    assert (
+        "resolution" not in payload
+    ), "Resolution should not have been set with `leave-open` keyword on bug."


### PR DESCRIPTION
Add some bug updating functionality when landing to an
`approval_required` (uplift) repository. Add an app config
to hold the `BMO_URL` so enable testing against dev and stage.
Add a new email notification function which is similar to the
landing failure email except with a standard error message.
