### PR TITLE
uplift: use `packaging.version.Version` to handle milestone version parsing (Bug 1788078)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -9,6 +9,7 @@ flake8-bugbear==19.3.0
 flake8==3.7.7
 mercurial==6.1.1
 moto==1.3.8
+packaging==21.3
 psycopg2==2.8.2
 pytest-flask==1.2.0
 pytest==7.1.1

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -4,15 +4,19 @@
 
 import pytest
 
+from packaging.version import (
+    Version,
+)
+
 from landoapi.phabricator import PhabricatorClient
 from landoapi.stacks import build_stack_graph
 from landoapi.uplift import (
     create_uplift_bug_update_payload,
     move_drev_to_original,
-    parse_milestone_major_version,
+    parse_milestone_version,
 )
 
-MILESTONE_TEST_CONTENTS = """
+MILESTONE_TEST_CONTENTS_1 = """
 # Holds the current milestone.
 # Should be in the format of
 #
@@ -28,11 +32,31 @@ MILESTONE_TEST_CONTENTS = """
 84.0a1
 """
 
+MILESTONE_TEST_CONTENTS_2 = """
+# Holds the current milestone.
+# Should be in the format of
+#
+#    x.x.x
+#    x.x.x.x
+#    x.x.x+
+#
+# Referenced by build/moz.configure/init.configure.
+# Hopefully I'll be able to automate replacement of *all*
+# hardcoded milestones in the tree from these two files.
+#--------------------------------------------------------
 
-def test_parse_milestone_major_version():
-    assert (
-        parse_milestone_major_version(MILESTONE_TEST_CONTENTS) == 84
-    ), "Test milestone file should have 84 as major milestone version."
+105.0
+"""
+
+
+def test_parse_milestone_version():
+    assert parse_milestone_version(MILESTONE_TEST_CONTENTS_1) == Version(
+        "84.0a1"
+    ), "Test milestone file 1 should have 84 as major milestone version."
+
+    assert parse_milestone_version(MILESTONE_TEST_CONTENTS_2) == Version(
+        "105.0"
+    ), "Test milestone file 2 should have 84 as major milestone version."
 
 
 def test_move_drev_to_original():

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -58,6 +58,10 @@ def test_parse_milestone_version():
         "105.0"
     ), "Test milestone file 2 should have 84 as major milestone version."
 
+    bad_milestone_contents = "blahblahblah"
+    with pytest.raises(ValueError, match=bad_milestone_contents):
+        parse_milestone_version(bad_milestone_contents)
+
 
 def test_move_drev_to_original():
     # Ensure `Differential Revision` is moved to `Original`.


### PR DESCRIPTION
The regex used to parse the major milestone version failed
on the content of the current beta (which is now in the tree
as a test case as `MILESTONE_TEST_CONTENTS_2`). This commit
changes the parsing to instead take the last line of the file
and pass to a `Version` object, which is returned from the
parsing function.
