### PR TITLE
phabricator: call `diffusion.looksoon` on landing to trigger repo sync (Bug 1455468, Bug 1788722)

### DIFF
--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -13,6 +13,7 @@ import subprocess
 import time
 
 import hglib
+import kombu
 from flask import current_app
 
 from landoapi import patches
@@ -31,12 +32,12 @@ from landoapi.notifications import (
     notify_user_of_bug_update_failure,
     notify_user_of_landing_failure,
 )
-from landoapi.phabricator import PhabricatorAPIException, PhabricatorClient
 from landoapi.repos import (
     Repo,
     repo_clone_subsystem,
 )
 from landoapi.storage import db, SQLAlchemy
+from landoapi.tasks import phab_trigger_repo_update
 from landoapi.treestatus import (
     TreeStatus,
     treestatus_subsystem,
@@ -264,6 +265,23 @@ class LandingWorker:
             f"Failed to update Bugzilla after landing uplift revisions: {str(exception)}",
             job.id,
         )
+
+    @staticmethod
+    def phab_trigger_repo_update(phab_identifier: str):
+        """Wrapper around `phab_trigger_repo_update` for convenience.
+
+        Args:
+            phab_identifier: `str` to be passed to Phabricator to identify
+            repo.
+        """
+        try:
+            # Send a Phab repo update task to Celery.
+            phab_trigger_repo_update.apply_async(args=(phab_identifier,))
+        except kombu.exceptions.OperationalError as e:
+            # Log the exception but continue gracefully.
+            # The repo will eventually update.
+            logger.exception("Failed sending repo update task to Celery.")
+            logger.exception(e)
 
     @staticmethod
     def extract_error_data(exception: str) -> tuple[list[str], list[str]]:
@@ -522,17 +540,8 @@ class LandingWorker:
                 # the landing user so they are aware and can update the bugs themselves.
                 self.notify_user_of_bug_update_failure(job, e)
 
-        try:
-            # Tell Phabricator to scan the landing repo so revisions are closed quickly.
-            phab = PhabricatorClient(
-                current_app.config["PHABRICATOR_URL"],
-                current_app.config["PHABRICATOR_UNPRIVILEGED_API_KEY"],
-            )
-            phab.call_conduit("diffusion.looksoon", repositories=[repo.phab_identifier])
-
-        except PhabricatorAPIException as e:
-            # Log the exception but continue gracefully.
-            logger.exception("Failed calling `diffusion.looksoon` to update Phab.")
-            logger.exception(e)
+        # Trigger update of repo in Phabricator so patches are closed quicker.
+        # Especially useful on low-traffic repositories.
+        self.phab_trigger_repo_update(repo.phab_identifier)
 
         return True

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -97,6 +97,11 @@ class Repo:
 
         return any(config.startswith("fix") for config in self.config_override.keys())
 
+    @property
+    def phab_identifier(self) -> str:
+        """Return a valid Phabricator identifier as a `str`."""
+        return self.short_name if self.short_name else self.tree
+
 
 SCM_ALLOW_DIRECT_PUSH = AccessGroup(
     active_group="active_scm_allow_direct_push",

--- a/landoapi/tasks.py
+++ b/landoapi/tasks.py
@@ -127,9 +127,10 @@ def send_bug_update_failure_email(
 @celery.task(
     autoretry_for=(IOError, PhabricatorCommunicationException),
     default_retry_delay=20,
-    max_retries=3 * 20,  # 20 minutes
     acks_late=True,
     ignore_result=True,
+    # Retry 3 times every 2 seconds.
+    max_retries=3 * 20,
 )
 def admin_remove_phab_project(
     revision_phid: str, project_phid: str, comment: Optional[str] = None
@@ -164,8 +165,7 @@ def admin_remove_phab_project(
 
 @celery.task(
     autoretry_for=(IOError, PhabricatorCommunicationException),
-    default_retry_delay=20,
-    max_retries=3 * 20,  # 20 minutes
+    default_retry_delay=3,
     acks_late=True,
     ignore_result=True,
 )

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,6 @@ datadog==0.44.0
 flake8-bugbear==19.3.0
 flake8==3.7.7
 mercurial==6.1.1
-mock==4.0.3
 moto==4.0.1
 packaging==21.3
 psycopg2==2.8.2

--- a/requirements.in
+++ b/requirements.in
@@ -8,12 +8,14 @@ datadog==0.44.0
 flake8-bugbear==19.3.0
 flake8==3.7.7
 mercurial==6.1.1
-moto==1.3.8
+mock==4.0.3
+moto==4.0.1
 packaging==21.3
 psycopg2==2.8.2
 pytest-flask==1.2.0
 pytest==7.1.1
 python-hglib==2.6.2
+python-jose==3.3.0
 redis==3.2.1
 requests-mock==1.6.0
 requests==2.27.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,19 +17,8 @@ attrs==21.4.0 \
     --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
     # via
     #   flake8-bugbear
-    #   jschema-to-python
     #   jsonschema
     #   pytest
-    #   sarif-om
-aws-sam-translator==1.45.0 \
-    --hash=sha256:40a6dd5a0aba32c7b38b0f5c54470396acdcd75e4b64251b015abdf922a18b5f \
-    --hash=sha256:bf321ab62aa1731d3e471fd55de6f5d1ab07dfc169cd254aa523dd9ad30246f9 \
-    --hash=sha256:cd4761c01902e5103e60202373275886e59edcc778edf18ca22d380059ed44e7
-    # via cfn-lint
-aws-xray-sdk==2.9.0 \
-    --hash=sha256:98216b3ac8281b51b59a8703f8ec561c460807d9d0679838f5c0179d381d7e58 \
-    --hash=sha256:b0cd972db218d4d8f7b53ad806fc6184626b924c4997ae58fc9f2a8cd1281568
-    # via moto
 billiard==3.6.4.0 \
     --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
     --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
@@ -62,21 +51,14 @@ black==22.3.0 \
 blinker==1.4 \
     --hash=sha256:471aee25f3992bd325afa3772f1063dbdbbca947a041b8b89466dc00d606f8b6
     # via sentry-sdk
-boto==2.49.0 \
-    --hash=sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8 \
-    --hash=sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
-    # via moto
 boto3==1.22.0 \
     --hash=sha256:733a651e76b37b10c1f7ccba53deae43e47ada8ae64128042632373c5d266cf7 \
     --hash=sha256:75310f5bb2af8f51f15f790d95dc4a4725bcec286f83458980ee2c3286cc0a03
-    # via
-    #   aws-sam-translator
-    #   moto
+    # via moto
 botocore==1.25.0 \
     --hash=sha256:38c04682e7554dbccb33cd37863d76eaff97922dfb72677d0b7a49f8dbadc373 \
     --hash=sha256:646f0631c4ee46928be2dbb4b44e10f5f184e70ed6efddb24bc7328d81d7a175
     # via
-    #   aws-xray-sdk
     #   boto3
     #   moto
     #   s3transfer
@@ -142,10 +124,6 @@ cffi==1.15.0 \
     --hash=sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997 \
     --hash=sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796
     # via cryptography
-cfn-lint==0.59.0 \
-    --hash=sha256:2dab012912d5869506258f0d4bb15d8e7f0ac2117e75fa599b50764fd867dba2 \
-    --hash=sha256:e5e98712cb162ee70eedd0fd8eae8d45d6420d43502e6120ad768f00ff1eec05
-    # via moto
 charset-normalizer==2.0.12 \
     --hash=sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597 \
     --hash=sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df
@@ -193,13 +171,9 @@ datadog==0.44.0 \
     --hash=sha256:071170f0c7ef22511dbf7f9bd76c4be500ee2d3d52072900a5c87b5495d2c733 \
     --hash=sha256:57c4878d3a8351f652792cdba78050274789dcc44313adec096e87f9d3ca5992
     # via -r requirements.in
-docker==5.0.3 \
-    --hash=sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0 \
-    --hash=sha256:d916a26b62970e7c2f554110ed6af04c7ccff8e9f81ad17d0d40c75637e227fb
-    # via moto
-ecdsa==0.17.0 \
-    --hash=sha256:5cf31d5b33743abe0dfc28999036c849a69d548f994b535e527ee3cb7f3ef676 \
-    --hash=sha256:b9f500bb439e4153d0330610f5d26baaf18d17b8ced1bc54410d189385ea68aa
+ecdsa==0.18.0 \
+    --hash=sha256:190348041559e21b22a1d65cee485282ca11a6f81d503fddb84d5017e9ed1e49 \
+    --hash=sha256:80600258e7ed2f16b9aa1d7c295bd70194109ad5a30fdee0eaeefef1d4c559dd
     # via python-jose
 entrypoints==0.3 \
     --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
@@ -238,9 +212,6 @@ flask-sqlalchemy==2.5.1 \
     --hash=sha256:2bda44b43e7cacb15d4e05ff3cc1f8bc97936cc464623424102bfc2c35e95912 \
     --hash=sha256:f12c3d4cc5cc7fdcc148b9527ea05671718c3ea45d50c7e732cceb33f574b390
     # via flask-migrate
-future==0.18.2 \
-    --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
-    # via aws-xray-sdk
 greenlet==1.1.2 \
     --hash=sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3 \
     --hash=sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711 \
@@ -301,9 +272,7 @@ greenlet==1.1.2 \
 idna==2.8 \
     --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
     --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
-    # via
-    #   moto
-    #   requests
+    # via requests
 importlib-metadata==4.11.3 \
     --hash=sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6 \
     --hash=sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539
@@ -334,35 +303,10 @@ jmespath==1.0.0 \
     # via
     #   boto3
     #   botocore
-jschema-to-python==1.2.3 \
-    --hash=sha256:76ff14fe5d304708ccad1284e4b11f96a658949a31ee7faed9e0995279549b91 \
-    --hash=sha256:8a703ca7604d42d74b2815eecf99a33359a8dccbb80806cce386d5e2dd992b05
-    # via cfn-lint
-jsondiff==1.1.2 \
-    --hash=sha256:7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21
-    # via moto
-jsonpatch==1.32 \
-    --hash=sha256:26ac385719ac9f54df8a2f0827bb8253aa3ea8ab7b3368457bcdb8c14595a397 \
-    --hash=sha256:b6ddfe6c3db30d81a96aaeceb6baf916094ffa23d7dd5fa2c13e13f8b6e600c2
-    # via cfn-lint
-jsonpickle==2.1.0 \
-    --hash=sha256:1dee77ddc5d652dfdabc33d33cff9d7e131d428007007da4fd6f7071ae774b0f \
-    --hash=sha256:84684cfc5338a534173c8dd69809e40f2865d0be1f8a2b7af8465e5b968dcfa9
-    # via jschema-to-python
-jsonpointer==2.3 \
-    --hash=sha256:51801e558539b4e9cd268638c078c6c5746c9ac96bc38152d443400e4f3793e9 \
-    --hash=sha256:97cba51526c829282218feb99dab1b1e6bdf8efd1c43dc9d57be093c0d69c99a
-    # via jsonpatch
 jsonschema==3.2.0 \
     --hash=sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163 \
     --hash=sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a
-    # via
-    #   aws-sam-translator
-    #   cfn-lint
-    #   connexion
-junit-xml==1.9 \
-    --hash=sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732
-    # via cfn-lint
+    # via connexion
 kombu==4.6.11 \
     --hash=sha256:be48cdffb54a2194d93ad6533d73f69408486483d189fe9f5990ee24255b0e0a \
     --hash=sha256:ca1b45faac8c0b18493d02a8571792f3c40291cf2bcf1f55afed3d8f3aa7ba74
@@ -415,6 +359,7 @@ markupsafe==2.1.1 \
     # via
     #   jinja2
     #   mako
+    #   moto
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
@@ -435,35 +380,26 @@ mercurial==6.1.1 \
 mock==4.0.3 \
     --hash=sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62 \
     --hash=sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc
-    # via moto
-moto==1.3.8 \
-    --hash=sha256:9cb02134148fbe3ed81f11d6ab9bd71bbd6bc2db7e59a45de77fb1d0fedb744e \
-    --hash=sha256:fc354598cb67cae1b18318b1e98955004bc27e05404a84ffa9c68654334638f2
+    # via -r requirements.in
+moto==4.0.1 \
+    --hash=sha256:6fb81f500c49f46f19f44b1db1c2ea56f19f90d0ca6b944866ae0f0eeab76398 \
+    --hash=sha256:a9529f295ac786ea80cdce682d57170f801c3618c3b540ced29d0473518f534d
     # via -r requirements.in
 mypy-extensions==0.4.3 \
     --hash=sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d \
     --hash=sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8
     # via black
-networkx==2.8 \
-    --hash=sha256:1a1e8fe052cc1b4e0339b998f6795099562a264a13a5af7a32cad45ab9d4e126 \
-    --hash=sha256:4a52cf66aed221955420e11b3e2e05ca44196b4829aab9576d4d439212b0a14f
-    # via cfn-lint
 packaging==21.3 \
     --hash=sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb \
     --hash=sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
     # via
+    #   -r requirements.in
     #   connexion
     #   pytest
 pathspec==0.9.0 \
     --hash=sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a \
     --hash=sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1
     # via black
-pbr==5.8.1 \
-    --hash=sha256:27108648368782d07bbf1cb468ad2e2eeef29086affd14087a6d04b7de8af4ec \
-    --hash=sha256:66bc5a34912f408bb3925bf21231cb6f59206267b7f63f3503ef865c1a292e25
-    # via
-    #   jschema-to-python
-    #   sarif-om
 platformdirs==2.5.2 \
     --hash=sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788 \
     --hash=sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19
@@ -556,7 +492,7 @@ python-hglib==2.6.2 \
 python-jose==3.3.0 \
     --hash=sha256:55779b5e6ad599c6336191246e95eb2293a9ddebd555f796a65f838f07e5d78a \
     --hash=sha256:9b1376b023f8b298536eedd47ae1089bcdb848f1535ab30555cd92002d78923a
-    # via moto
+    # via -r requirements.in
 pytz==2022.1 \
     --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
     --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
@@ -598,10 +534,8 @@ pyyaml==6.0 \
     --hash=sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174 \
     --hash=sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5
     # via
-    #   cfn-lint
     #   clickclick
     #   connexion
-    #   moto
 redis==3.2.1 \
     --hash=sha256:6946b5dca72e86103edc8033019cc3814c031232d339d5f4533b02ea85685175 \
     --hash=sha256:8ca418d2ddca1b1a850afa1680a7d2fd1f3322739271de4b704e0d4668449273
@@ -613,7 +547,6 @@ requests==2.27.1 \
     #   -r requirements.in
     #   connexion
     #   datadog
-    #   docker
     #   moto
     #   requests-mock
     #   responses
@@ -636,18 +569,14 @@ rs-parsepatch==0.3.6 \
     --hash=sha256:d3d1e72ebb2c2cf22fb6fec85c231ab8e210102283683f2938f757dc805b2340 \
     --hash=sha256:fe83e61c4df3c359cad18887ad4e2ca1f6cb67d6dd9b475e36172de43b9bfd0d
     # via -r requirements.in
-rsa==4.8 \
-    --hash=sha256:5c6bd9dc7a543b7fe4304a631f8a8a3b674e2bbfc49c2ae96200cdbe55df6b17 \
-    --hash=sha256:95c5d300c4e879ee69708c428ba566c59478fd653cc3a22243eeb8ed846950bb
+rsa==4.9 \
+    --hash=sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7 \
+    --hash=sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21
     # via python-jose
 s3transfer==0.5.2 \
     --hash=sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971 \
     --hash=sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed
     # via boto3
-sarif-om==1.0.4 \
-    --hash=sha256:539ef47a662329b1c8502388ad92457425e95dc0aaaf995fe46f4984c4771911 \
-    --hash=sha256:cd5f416b3083e00d402a92e449a7ff67af46f11241073eea0461802a3b5aef98
-    # via cfn-lint
 sentry-sdk[flask]==1.5.8 \
     --hash=sha256:32af1a57954576709242beb8c373b3dbde346ac6bd616921def29d68846fb8c3 \
     --hash=sha256:38fd16a92b5ef94203db3ece10e03bdaa291481dd7e00e77a148aa0302267d47
@@ -658,8 +587,6 @@ six==1.16.0 \
     # via
     #   ecdsa
     #   jsonschema
-    #   junit-xml
-    #   moto
     #   python-dateutil
     #   requests-mock
 sqlalchemy==1.4.35 \
@@ -729,10 +656,6 @@ vine==1.3.0 \
     # via
     #   amqp
     #   celery
-websocket-client==1.3.2 \
-    --hash=sha256:50b21db0058f7a953d67cc0445be4b948d7fc196ecbeb8083d68d94628e4abf6 \
-    --hash=sha256:722b171be00f2b90e1d4fb2f2b53146a536ca38db1da8ff49c972a4e1365d0ef
-    # via docker
 werkzeug==2.1.1 \
     --hash=sha256:3c5493ece8268fecdcdc9c0b112211acd006354723b280d643ec732b6d4063d6 \
     --hash=sha256:f8e89a20aeabbe8a893c24a461d3ee5dad2123b05cc6abd73ceed01d39c3ae74
@@ -741,72 +664,6 @@ werkzeug==2.1.1 \
     #   flask
     #   moto
     #   pytest-flask
-wrapt==1.14.0 \
-    --hash=sha256:00108411e0f34c52ce16f81f1d308a571df7784932cc7491d1e94be2ee93374b \
-    --hash=sha256:01f799def9b96a8ec1ef6b9c1bbaf2bbc859b87545efbecc4a78faea13d0e3a0 \
-    --hash=sha256:09d16ae7a13cff43660155383a2372b4aa09109c7127aa3f24c3cf99b891c330 \
-    --hash=sha256:14e7e2c5f5fca67e9a6d5f753d21f138398cad2b1159913ec9e9a67745f09ba3 \
-    --hash=sha256:167e4793dc987f77fd476862d32fa404d42b71f6a85d3b38cbce711dba5e6b68 \
-    --hash=sha256:1807054aa7b61ad8d8103b3b30c9764de2e9d0c0978e9d3fc337e4e74bf25faa \
-    --hash=sha256:1f83e9c21cd5275991076b2ba1cd35418af3504667affb4745b48937e214bafe \
-    --hash=sha256:21b1106bff6ece8cb203ef45b4f5778d7226c941c83aaaa1e1f0f4f32cc148cd \
-    --hash=sha256:22626dca56fd7f55a0733e604f1027277eb0f4f3d95ff28f15d27ac25a45f71b \
-    --hash=sha256:23f96134a3aa24cc50614920cc087e22f87439053d886e474638c68c8d15dc80 \
-    --hash=sha256:2498762814dd7dd2a1d0248eda2afbc3dd9c11537bc8200a4b21789b6df6cd38 \
-    --hash=sha256:28c659878f684365d53cf59dc9a1929ea2eecd7ac65da762be8b1ba193f7e84f \
-    --hash=sha256:2eca15d6b947cfff51ed76b2d60fd172c6ecd418ddab1c5126032d27f74bc350 \
-    --hash=sha256:354d9fc6b1e44750e2a67b4b108841f5f5ea08853453ecbf44c81fdc2e0d50bd \
-    --hash=sha256:36a76a7527df8583112b24adc01748cd51a2d14e905b337a6fefa8b96fc708fb \
-    --hash=sha256:3a0a4ca02752ced5f37498827e49c414d694ad7cf451ee850e3ff160f2bee9d3 \
-    --hash=sha256:3a71dbd792cc7a3d772ef8cd08d3048593f13d6f40a11f3427c000cf0a5b36a0 \
-    --hash=sha256:3a88254881e8a8c4784ecc9cb2249ff757fd94b911d5df9a5984961b96113fff \
-    --hash=sha256:47045ed35481e857918ae78b54891fac0c1d197f22c95778e66302668309336c \
-    --hash=sha256:4775a574e9d84e0212f5b18886cace049a42e13e12009bb0491562a48bb2b758 \
-    --hash=sha256:493da1f8b1bb8a623c16552fb4a1e164c0200447eb83d3f68b44315ead3f9036 \
-    --hash=sha256:4b847029e2d5e11fd536c9ac3136ddc3f54bc9488a75ef7d040a3900406a91eb \
-    --hash=sha256:59d7d92cee84a547d91267f0fea381c363121d70fe90b12cd88241bd9b0e1763 \
-    --hash=sha256:5a0898a640559dec00f3614ffb11d97a2666ee9a2a6bad1259c9facd01a1d4d9 \
-    --hash=sha256:5a9a1889cc01ed2ed5f34574c90745fab1dd06ec2eee663e8ebeefe363e8efd7 \
-    --hash=sha256:5b835b86bd5a1bdbe257d610eecab07bf685b1af2a7563093e0e69180c1d4af1 \
-    --hash=sha256:5f24ca7953f2643d59a9c87d6e272d8adddd4a53bb62b9208f36db408d7aafc7 \
-    --hash=sha256:61e1a064906ccba038aa3c4a5a82f6199749efbbb3cef0804ae5c37f550eded0 \
-    --hash=sha256:65bf3eb34721bf18b5a021a1ad7aa05947a1767d1aa272b725728014475ea7d5 \
-    --hash=sha256:6807bcee549a8cb2f38f73f469703a1d8d5d990815c3004f21ddb68a567385ce \
-    --hash=sha256:68aeefac31c1f73949662ba8affaf9950b9938b712fb9d428fa2a07e40ee57f8 \
-    --hash=sha256:6915682f9a9bc4cf2908e83caf5895a685da1fbd20b6d485dafb8e218a338279 \
-    --hash=sha256:6d9810d4f697d58fd66039ab959e6d37e63ab377008ef1d63904df25956c7db0 \
-    --hash=sha256:729d5e96566f44fccac6c4447ec2332636b4fe273f03da128fff8d5559782b06 \
-    --hash=sha256:748df39ed634851350efa87690c2237a678ed794fe9ede3f0d79f071ee042561 \
-    --hash=sha256:763a73ab377390e2af26042f685a26787c402390f682443727b847e9496e4a2a \
-    --hash=sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311 \
-    --hash=sha256:8529b07b49b2d89d6917cfa157d3ea1dfb4d319d51e23030664a827fe5fd2131 \
-    --hash=sha256:87fa943e8bbe40c8c1ba4086971a6fefbf75e9991217c55ed1bcb2f1985bd3d4 \
-    --hash=sha256:88236b90dda77f0394f878324cfbae05ae6fde8a84d548cfe73a75278d760291 \
-    --hash=sha256:891c353e95bb11abb548ca95c8b98050f3620a7378332eb90d6acdef35b401d4 \
-    --hash=sha256:89ba3d548ee1e6291a20f3c7380c92f71e358ce8b9e48161401e087e0bc740f8 \
-    --hash=sha256:8c6be72eac3c14baa473620e04f74186c5d8f45d80f8f2b4eda6e1d18af808e8 \
-    --hash=sha256:9a242871b3d8eecc56d350e5e03ea1854de47b17f040446da0e47dc3e0b9ad4d \
-    --hash=sha256:9a3ff5fb015f6feb78340143584d9f8a0b91b6293d6b5cf4295b3e95d179b88c \
-    --hash=sha256:9a5a544861b21e0e7575b6023adebe7a8c6321127bb1d238eb40d99803a0e8bd \
-    --hash=sha256:9d57677238a0c5411c76097b8b93bdebb02eb845814c90f0b01727527a179e4d \
-    --hash=sha256:9d8c68c4145041b4eeae96239802cfdfd9ef927754a5be3f50505f09f309d8c6 \
-    --hash=sha256:9d9fcd06c952efa4b6b95f3d788a819b7f33d11bea377be6b8980c95e7d10775 \
-    --hash=sha256:a0057b5435a65b933cbf5d859cd4956624df37b8bf0917c71756e4b3d9958b9e \
-    --hash=sha256:a65bffd24409454b889af33b6c49d0d9bcd1a219b972fba975ac935f17bdf627 \
-    --hash=sha256:b0ed6ad6c9640671689c2dbe6244680fe8b897c08fd1fab2228429b66c518e5e \
-    --hash=sha256:b21650fa6907e523869e0396c5bd591cc326e5c1dd594dcdccac089561cacfb8 \
-    --hash=sha256:b3f7e671fb19734c872566e57ce7fc235fa953d7c181bb4ef138e17d607dc8a1 \
-    --hash=sha256:b77159d9862374da213f741af0c361720200ab7ad21b9f12556e0eb95912cd48 \
-    --hash=sha256:bb36fbb48b22985d13a6b496ea5fb9bb2a076fea943831643836c9f6febbcfdc \
-    --hash=sha256:d066ffc5ed0be00cd0352c95800a519cf9e4b5dd34a028d301bdc7177c72daf3 \
-    --hash=sha256:d332eecf307fca852d02b63f35a7872de32d5ba8b4ec32da82f45df986b39ff6 \
-    --hash=sha256:d808a5a5411982a09fef6b49aac62986274ab050e9d3e9817ad65b2791ed1425 \
-    --hash=sha256:d9bdfa74d369256e4218000a629978590fd7cb6cf6893251dad13d051090436d \
-    --hash=sha256:db6a0ddc1282ceb9032e41853e659c9b638789be38e5b8ad7498caac00231c23 \
-    --hash=sha256:debaf04f813ada978d7d16c7dfa16f3c9c2ec9adf4656efdc4defdf841fc2f0c \
-    --hash=sha256:f0408e2dbad9e82b4c960274214af533f856a199c9274bd4aff55d4634dedc33 \
-    --hash=sha256:f2f3bc7cd9c9fcd39143f11342eb5963317bd54ecc98e3650ca22704b69d9653
-    # via aws-xray-sdk
 xmltodict==0.12.0 \
     --hash=sha256:50d8c638ed7ecb88d90561beedbf720c9b4e851a9fa6c47ebd64e99d166d8a21 \
     --hash=sha256:8bbcb45cc982f48b2ca8fe7e7827c5d792f217ecf1792626f808bf41c3b86051

--- a/requirements.txt
+++ b/requirements.txt
@@ -377,10 +377,6 @@ mercurial==6.1.1 \
     --hash=sha256:d381614c41c80f061c8f2df532e75fb14c440b9c41461848c6a7702df496f237 \
     --hash=sha256:ff338578db5d415a8134d0dc8e5b8f892ca4ea30dc8b4b3eaeef3719a753cc1e
     # via -r requirements.in
-mock==4.0.3 \
-    --hash=sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62 \
-    --hash=sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc
-    # via -r requirements.in
 moto==4.0.1 \
     --hash=sha256:6fb81f500c49f46f19f44b1db1c2ea56f19f90d0ca6b944866ae0f0eeab76398 \
     --hash=sha256:a9529f295ac786ea80cdce682d57170f801c3618c3b540ced29d0473518f534d

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import mock
 import pytest
 import textwrap
+import unittest.mock as mock
 
 from landoapi import patches
 from landoapi.hg import HgRepo

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -252,7 +252,15 @@ aDd oNe mOrE LiNe
 
 
 def test_integrated_execute_job(
-    app, db, s3, mock_repo_config, hg_server, hg_clone, treestatusdouble, upload_patch
+    app,
+    db,
+    s3,
+    mock_repo_config,
+    hg_server,
+    hg_clone,
+    treestatusdouble,
+    monkeypatch,
+    upload_patch,
 ):
     treestatus = treestatusdouble.get_treestatus_client()
     treestatusdouble.open_tree("mozilla-central")
@@ -278,9 +286,19 @@ def test_integrated_execute_job(
 
     worker = LandingWorker(sleep_seconds=0.01)
 
+    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "landoapi.landing_worker.LandingWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
     assert job.status == LandingJobStatus.LANDED
     assert len(job.landed_commit_id) == 40
+    assert (
+        mock_trigger_update.call_count == 1
+    ), "Successful landing should trigger Phab repo update."
 
 
 def test_lose_push_race(
@@ -417,7 +435,15 @@ def test_landing_worker__extract_error_data():
 
 
 def test_format_patch_success_unchanged(
-    app, db, s3, mock_repo_config, hg_server, hg_clone, treestatusdouble, upload_patch
+    app,
+    db,
+    s3,
+    mock_repo_config,
+    hg_server,
+    hg_clone,
+    treestatusdouble,
+    monkeypatch,
+    upload_patch,
 ):
     """Tests automated formatting happy path where formatters made no changes."""
     treestatus = treestatusdouble.get_treestatus_client()
@@ -447,15 +473,33 @@ def test_format_patch_success_unchanged(
 
     worker = LandingWorker(sleep_seconds=0.01)
 
+    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "landoapi.landing_worker.LandingWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
     assert worker.run_job(job, repo, hgrepo, treestatus, "landoapi.test.bucket")
     assert (
         job.status == LandingJobStatus.LANDED
     ), "Successful landing should set `LANDED` status."
     assert job.formatted_replacements is None
+    assert (
+        mock_trigger_update.call_count == 1
+    ), "Successful landing should trigger Phab repo update."
 
 
 def test_format_patch_success_changed(
-    app, db, s3, mock_repo_config, hg_server, hg_clone, treestatusdouble, upload_patch
+    app,
+    db,
+    s3,
+    mock_repo_config,
+    hg_server,
+    hg_clone,
+    treestatusdouble,
+    monkeypatch,
+    upload_patch,
 ):
     """Tests automated formatting happy path where formatters made
     changes before landing.
@@ -490,6 +534,13 @@ def test_format_patch_success_changed(
 
     worker = LandingWorker(sleep_seconds=0.01)
 
+    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "landoapi.landing_worker.LandingWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
     # The landed commit hashes affected by autoformat
     formatted_replacements = [
         "12be32a8a3ff283e0836b82be959fbd024cf271b",
@@ -505,6 +556,9 @@ def test_format_patch_success_changed(
     assert (
         job.formatted_replacements == formatted_replacements
     ), "Did not correctly save hashes of formatted revisions"
+    assert (
+        mock_trigger_update.call_count == 1
+    ), "Successful landing should trigger Phab repo update."
 
     with hgrepo.for_push(job.requester_email):
         # Get repo root since `-R` does not change relative directory, so
@@ -636,6 +690,13 @@ def test_format_patch_no_landoini(
 
     worker = LandingWorker(sleep_seconds=0.01)
 
+    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "landoapi.landing_worker.LandingWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
     # Mock `notify_user_of_landing_failure` so we can make sure that it was called.
     mock_notify = mock.MagicMock()
     monkeypatch.setattr(
@@ -649,3 +710,6 @@ def test_format_patch_no_landoini(
     assert (
         mock_notify.call_count == 0
     ), "Should not notify user of landing failure due to `.lando.ini` missing."
+    assert (
+        mock_trigger_update.call_count == 1
+    ), "Successful landing should trigger Phab repo update."


### PR DESCRIPTION
Adds a call to Phabricator's `diffusion.looksoon` API to trigger
syncing from the upstream repo. This should cause revisions
to close faster, especially on uplift repositories.

As part of this patch some tests were failing due to out of date
`moto` conflicting with `responses`. Upgrading `moto` caused the
removal of several packages that are used directly in testing and
the main application. These packages are added to `requirements.in`
so they are explicit dependencies.
