### PR TITLE
hg: add email validation for hg users (bug 1691635)

### DIFF
--- a/landoapi/validation.py
+++ b/landoapi/validation.py
@@ -6,6 +6,7 @@ import re
 from connexion import ProblemException
 
 REVISION_ID_RE = re.compile(r"^D(?P<id>[1-9][0-9]*)$")
+VALID_EMAIL_RE = re.compile(r"[^@ \t\r\n]+@[^@ \t\r\n]+\.[^@ \t\r\n]+")
 
 
 def revision_id_to_int(revision_id: str) -> int:
@@ -35,3 +36,8 @@ def parse_landing_path(landing_path: list[dict]) -> list[tuple[int, int]]:
             f"The provided landing_path was malformed.\n{str(e)}",
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
+
+
+def is_valid_email(email: str) -> bool:
+    """Given a string, determines if it is a valid email."""
+    return VALID_EMAIL_RE.match(email) is not None

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -173,6 +173,37 @@ diff --git a/test.txt b/test.txt
 +adding another line
 """.strip()
 
+PATCH_NO_EMAIL = b"""
+# HG changeset patch
+# User Test User
+# Date 0 0
+#      Thu Jan 01 00:00:00 1970 +0000
+# Diff Start Line 7
+add another file.
+diff --git a/test.txt b/test.txt
+--- a/test.txt
++++ b/test.txt
+@@ -1,1 +1,2 @@
+ TEST
++adding another line
+""".strip()
+
+
+PATCH_INVALID_EMAIL = b"""
+# HG changeset patch
+# User Test User <test@example>
+# Date 0 0
+#      Thu Jan 01 00:00:00 1970 +0000
+# Diff Start Line 7
+add another file.
+diff --git a/test.txt b/test.txt
+--- a/test.txt
++++ b/test.txt
+@@ -1,1 +1,2 @@
+ TEST
++adding another line
+""".strip()
+
 
 def test_integrated_hgrepo_apply_patch(hg_clone):
     repo = HgRepo(hg_clone.strpath)
@@ -185,6 +216,14 @@ def test_integrated_hgrepo_apply_patch(hg_clone):
     # Patches with conflicts should raise a proper PatchConflict exception.
     with pytest.raises(PatchConflict), repo.for_pull():
         repo.apply_patch(io.BytesIO(PATCH_WITH_CONFLICT))
+
+    # Mercurial users with invalid emails raise an error
+    with pytest.raises(ValueError), repo.for_pull():
+        repo.apply_patch(io.BytesIO(PATCH_INVALID_EMAIL))
+
+    # Mercurial users with no email configured raise an error
+    with pytest.raises(ValueError), repo.for_pull():
+        repo.apply_patch(io.BytesIO(PATCH_NO_EMAIL))
 
     with repo.for_pull():
         repo.apply_patch(io.BytesIO(PATCH_NORMAL))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -4,7 +4,7 @@
 import pytest
 from connexion import ProblemException
 
-from landoapi.validation import revision_id_to_int
+from landoapi.validation import revision_id_to_int, is_valid_email
 
 
 def test_convertion_success():
@@ -20,3 +20,11 @@ def test_convertion_failure_string(id):
 def test_convertion_failure_integer():
     with pytest.raises(TypeError):
         revision_id_to_int(123)
+
+
+def test_is_valid_email():
+    invalid_email = "Test User"
+    valid_email = "test@mozilla.com"
+
+    assert not is_valid_email(invalid_email)
+    assert is_valid_email(valid_email)


### PR DESCRIPTION
while moz-phab will hopefully catch invalid emails before they make it to lando now, this PR adds an extra safeguard against incorrectly configured mercurial users' commits landing in a repo

[Bug 1691635 - Lando landed a commit without a valid email address](https://bugzilla.mozilla.org/show_bug.cgi?id=1691635)