### PR TITLE
landing_worker: make `sleep_seconds` a float (Bug 1759890)

### DIFF
--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -75,7 +75,7 @@ def job_processing(worker: LandingWorker, job: LandingJob, db: SQLAlchemy):
 
 
 class LandingWorker:
-    def __init__(self, sleep_seconds=5):
+    def __init__(self, sleep_seconds: float = 5.0):
         SSH_PRIVATE_KEY_ENV_KEY = "SSH_PRIVATE_KEY"
 
         self.sleep_seconds = sleep_seconds


### PR DESCRIPTION
The default value for `sleep_seconds` is an
`int`, but elsewhere in the codebase we pass values
for `sleep_seconds` as a `float`. Change the default
value to a `float` as well to avoid type checker errors.
