### PR TITLE
autoformat: stop adding `mach lint` output to commit message (Bug 1802406)

### DIFF
--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -752,7 +752,7 @@ def test_format_stack_success_changed(
     ), "Commit message for autoformat commit should contain `# ignore-this-changeset`."
 
     assert (
-        desc == AUTOFORMAT_COMMIT_MESSAGE.format(output="").strip()
+        desc == AUTOFORMAT_COMMIT_MESSAGE
     ), "Autoformat commit has incorrect commit message."
 
 


### PR DESCRIPTION
The output can be littered with irrelevant information, leading
to overly verbose commit messages that don't work well with
Git/Hg etc.
