### PR TITLE
diff_warnings: add comma so each line is a different argument (Bug 1802553)

### DIFF
--- a/landoapi/api/diff_warnings.py
+++ b/landoapi/api/diff_warnings.py
@@ -53,7 +53,7 @@ def delete(pk):
     if not warning:
         return problem(
             400,
-            "DiffWarning does not exist"
+            "DiffWarning does not exist",
             f"DiffWarning with primary key {pk} does not exist",
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )


### PR DESCRIPTION
There is a missing comma which causes two lines to be joined
into one by Python. These two lines should each be their own
argument. Add a comma to fix this problem.
