### PR TITLE
typing: set `scopes` type to `Iterable` (Bug 1759890)

### DIFF
--- a/landoapi/auth.py
+++ b/landoapi/auth.py
@@ -8,6 +8,8 @@ import hmac
 import logging
 import os
 
+from collections.abc import Iterable
+
 from typing import (
     Callable,
     Optional,
@@ -354,7 +356,7 @@ class require_auth0:
     accessed using flask.g.auth0_user.
     """
 
-    def __init__(self, scopes: Optional[tuple[str]] = None, userinfo: bool = False):
+    def __init__(self, scopes: Optional[Iterable[str]] = None, userinfo: bool = False):
         assert scopes is not None, (
             "`scopes` must be provided. If this endpoint truly does not "
             "require any scopes, explicilty pass an empty tuple `()`"


### PR DESCRIPTION
The `scopes` type is set to `tuple[str]`, which implies to type
checkers that the type is always a single `str` element tuple.
Since we are passing `tuple`'s of different length in various
places, it is more appropriate for the type to be `Iterable`,
which also aligns with the docstring comment about `scopes`.

Use the `Iterable` from `collections.abc` as that is the
preferred way in Python 3.9+.
