### PR TITLE
autoformat: add bug numbers to autoformat commit messages (Bug 1802558)

### DIFF
--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -198,3 +198,11 @@ def split_title_and_summary(msg: str) -> Tuple[str, str]:
     tail = parts[1:]
     summary = "\n".join(tail).strip()
     return title, summary
+
+
+def bug_list_to_commit_string(bug_ids: List[str]):
+    """Convert a list of `str` bug IDs to a string for a commit message."""
+    if not bug_ids:
+        return "No bug"
+
+    return f"Bug {', '.join(bug_ids)}"

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -200,7 +200,7 @@ def split_title_and_summary(msg: str) -> Tuple[str, str]:
     return title, summary
 
 
-def bug_list_to_commit_string(bug_ids: List[str]):
+def bug_list_to_commit_string(bug_ids: List[str]) -> str:
     """Convert a list of `str` bug IDs to a string for a commit message."""
     if not bug_ids:
         return "No bug"

--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -17,6 +17,7 @@ from typing import List, Optional
 
 import hglib
 
+from landoapi.commit_message import bug_list_to_commit_string
 from landoapi.hgexports import PatchHelper
 
 logger = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ class AutoformattingException(Exception):
 
 
 AUTOFORMAT_COMMIT_MESSAGE = """
-No bug: apply code formatting via Lando
+{bugs}: apply code formatting via Lando
 
 # ignore-this-changeset
 """.strip()
@@ -456,19 +457,21 @@ class HgRepo:
 
             raise exc
 
-    def format_stack_tip(self) -> Optional[List[str]]:
+    def format_stack_tip(self, bug_ids: List[str]) -> Optional[List[str]]:
         """Add an autoformat commit to the top of the patch stack.
 
         Return the commit hash of the autoformat commit as a `str`,
         or return `None` if autoformatting made no changes.
         """
+        bug_string = bug_list_to_commit_string(bug_ids)
+
         try:
             # Create a new commit.
             self.run_hg(
                 ["commit"]
                 + [
                     "--message",
-                    AUTOFORMAT_COMMIT_MESSAGE,
+                    AUTOFORMAT_COMMIT_MESSAGE.format(bugs=bug_string),
                 ]
                 + ["--landing_system", "lando"]
             )
@@ -482,7 +485,7 @@ class HgRepo:
 
             raise exc
 
-    def format_stack(self, stack_size: int) -> Optional[List[str]]:
+    def format_stack(self, stack_size: int, bug_ids: List[str]) -> Optional[List[str]]:
         """Format the patch stack for landing.
 
         Return a list of `str` commit hashes where autoformatting was applied,
@@ -519,7 +522,7 @@ class HgRepo:
                 return self.format_stack_amend()
 
             # If the stack is more than a single commit, create an autoformat commit.
-            return self.format_stack_tip()
+            return self.format_stack_tip(bug_ids)
 
         except HgException as exc:
             logger.warning("Failed to create an autoformat commit.")

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -23,7 +23,6 @@ from flask import current_app
 
 from landoapi import bmo
 from landoapi.cache import cache, DEFAULT_CACHE_KEY_TIMEOUT_SECONDS
-from landoapi.commit_message import parse_bugs
 from landoapi.phabricator import PhabricatorClient, PhabricatorAPIException
 from landoapi.phabricator_patch import patch_to_changes
 from landoapi.projects import RELMAN_PROJECT_SLUG
@@ -361,12 +360,9 @@ def create_uplift_bug_update_payload(
 def update_bugs_for_uplift(
     repo_name: str,
     milestone_file_contents: str,
-    changeset_titles: list[str],
+    bug_ids: list[str],
 ):
     """Update Bugzilla bugs for uplift."""
-    # Parse bug numbers from commits in the stack.
-    bug_ids = [str(bug) for title in changeset_titles for bug in parse_bugs(title)]
-
     if not bug_ids:
         raise ValueError("No bugs found in uplift landing.")
 

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -3,7 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import pytest
 
-from landoapi.commit_message import format_commit_message, split_title_and_summary
+from landoapi.commit_message import (
+    bug_list_to_commit_string,
+    format_commit_message,
+    split_title_and_summary,
+)
 
 COMMIT_MESSAGE = """
 Bug 1 - A title. r=reviewer_one,reviewer.two
@@ -194,3 +198,15 @@ def test_relman_reviews_become_approvals():
         "Original Revision: http://phabricator.test/D1\n\n"
         "Differential Revision: http://phabricator.test/D123",
     )
+
+
+def test_bug_list_to_commit_string():
+    assert (
+        bug_list_to_commit_string([]) == "No bug"
+    ), "Empty input should return `No bug`"
+    assert (
+        bug_list_to_commit_string(["123"]) == "Bug 123"
+    ), "Single bug should return with `bug` and number."
+    assert (
+        bug_list_to_commit_string(["123", "456"]) == "Bug 123, 456"
+    ), "Multiple bugs should return comma separated list."

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -298,7 +298,7 @@ PATCH_FORMATTED_1 = r"""
 # Date 0 0
 #      Thu Jan 01 00:00:00 1970 +0000
 # Diff Start Line 7
-add another file for formatting 1
+bug 123: add another file for formatting 1
 
 diff --git a/test.txt b/test.txt
 --- a/test.txt
@@ -667,7 +667,7 @@ def test_format_single_success_changed(
     assert tip_content == TESTTXT_FORMATTED_1, "`test.txt` is incorrect in base commit."
 
     assert (
-        desc == "add another file for formatting 1"
+        desc == "bug 123: add another file for formatting 1"
     ), "Autoformat via amend should not change commit message."
 
     assert (
@@ -751,8 +751,8 @@ def test_format_stack_success_changed(
         "# ignore-this-changeset" in desc
     ), "Commit message for autoformat commit should contain `# ignore-this-changeset`."
 
-    assert (
-        desc == AUTOFORMAT_COMMIT_MESSAGE
+    assert desc == AUTOFORMAT_COMMIT_MESSAGE.format(
+        bugs="Bug 123"
     ), "Autoformat commit has incorrect commit message."
 
 


### PR DESCRIPTION
Instead of having `No bug` in the commit message title,
use the bug numbers from all changesets in the stack.
Move collection of stack changeset titles earlier in
the job processing and parse bug IDs at the landing
job level, passing the ids into the formatting function
as well as into the uplift code where they were previously
parsed. Add a function `bug_list_to_commit_string` to
convert these bug IDs into an appropriate bug string
and add this string to the autoformat commit message
template. Update the test commit messages with a bug
number to ensure the parsing is correct.
