### PR TITLE
typing: add hints and clarify types in various places (Bug 1759890)

### DIFF
--- a/landoapi/api/uplift.py
+++ b/landoapi/api/uplift.py
@@ -39,8 +39,8 @@ def get():
 def create(data):
     """Create new uplift requests for requested repository & revision"""
     repo_name = data["repository"]
-    landing_path = parse_landing_path(data["landing_path"])
-    tip_revision_id = landing_path[-1][0]
+    landing_path_ids = parse_landing_path(data["landing_path"])
+    tip_revision_id = landing_path_ids[-1][0]
     phab: PhabricatorClient = g.phabricator
 
     # Validate repository.
@@ -89,9 +89,9 @@ def create(data):
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
         )
 
-    landing_path = convert_path_id_to_phid(landing_path, revision_data)
+    landing_path_phids = convert_path_id_to_phid(landing_path_ids, revision_data)
     commit_stack = []
-    for rev_id, _diff_id in landing_path:
+    for rev_id, _diff_id in landing_path_phids:
         # Get the relevant revision.
         revision = revision_data.revisions[rev_id]
 

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Add revision data to commit message."""
 import re
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 REVISION_URL_TEMPLATE = "Differential Revision: {url}"
 
@@ -67,7 +67,7 @@ METADATA_RE = re.compile("^MozReview-Commit-ID: ")
 
 def format_commit_message(
     title: str,
-    bug: str,
+    bug: Optional[int],
     reviewers: List[str],
     approvals: List[str],
     summary: str,

--- a/landoapi/revisions.py
+++ b/landoapi/revisions.py
@@ -33,7 +33,7 @@ from landoapi.uplift import (
 logger = logging.getLogger(__name__)
 
 
-def gather_involved_phids(revision):
+def gather_involved_phids(revision: dict) -> set[str]:
     """Return the set of Phobject phids involved in a revision.
 
     At the time of writing Users and Projects are the type of Phobjects
@@ -118,7 +118,7 @@ def select_diff_author(diff):
     return authors[0][0] if authors else (None, None)
 
 
-def get_bugzilla_bug(revision):
+def get_bugzilla_bug(revision: dict) -> Optional[int]:
     bug = PhabricatorClient.expect(revision, "fields").get("bugzilla.bug-id")
     return int(bug) if bug else None
 

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -502,13 +502,18 @@ def get_blocker_checks(
     ]
 
 
-def convert_path_id_to_phid(path, stack_data):
+def convert_path_id_to_phid(
+    landing_path: list[tuple[int, int]], stack_data: RevisionData
+) -> list[tuple[str, int]]:
+    """Convert a landing path list into a mapping of PHIDs to `int` diff IDs."""
     mapping = {
         PhabricatorClient.expect(r, "id"): PhabricatorClient.expect(r, "phid")
         for r in stack_data.revisions.values()
     }
     try:
-        mapped = [(mapping[r], d) for r, d in path]
+        mapped = [
+            (mapping[revision_id], diff_id) for revision_id, diff_id in landing_path
+        ]
     except IndexError:
         raise ProblemException(
             400,

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -98,7 +98,7 @@ def parse_milestone_version(milestone_contents: str) -> Version:
         ) from e
 
 
-def get_uplift_request_form(revision) -> Optional[str]:
+def get_uplift_request_form(revision: dict) -> Optional[str]:
     """Return the content of the uplift request form or `None` if missing."""
     bug = PhabricatorClient.expect(revision, "fields").get("uplift.request")
     return bug

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -180,7 +180,7 @@ def test_split_title_and_summary(message, title, summary):
 def test_relman_reviews_become_approvals():
     commit_message = format_commit_message(
         "A title r?#release-managers!",
-        "1",
+        1,
         [],
         ["ryanvm"],
         ("A summary.\n" "\n" "Original Revision: http://phabricator.test/D1"),


### PR DESCRIPTION
- Add type hints and clarify `convert_path_id_to_phid`.
- Split landing_path into two variables with different types.
- Add type hints for gather_involved_phids.
- Add type hint to get_uplift_request_form.
- Add type hints for get_bugzilla_bug.
- Make format_commit_message type correct everywhere.
