### PR TITLE
autoformatting: add a details field to `AutoformattingException` and populate with mach output (Bug 1803169)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -105,7 +105,14 @@ class PatchConflict(PatchApplicationFailure):
 class AutoformattingException(Exception):
     """Exception when autoformatting fails to format a patch stack."""
 
-    pass
+    def __init__(self, *args: object, details: Optional[str] = None) -> None:
+        super().__init__(*args)
+
+        self._details = details
+
+    def details(self) -> str:
+        """Return error details for display."""
+        return self._details if self._details else str(self)
 
 
 AUTOFORMAT_COMMIT_MESSAGE = """
@@ -510,8 +517,9 @@ class HgRepo:
             logger.exception(exc)
 
             raise AutoformattingException(
-                "Failed to run automated code formatters."
-            ) from exc
+                "Failed to run automated code formatters.",
+                details=exc.stdout,
+            )
 
         try:
             # When the stack is just a single commit, amend changes into it.
@@ -526,8 +534,9 @@ class HgRepo:
             logger.exception(exc)
 
             raise AutoformattingException(
-                "Failed to apply code formatting changes to the repo."
-            ) from exc
+                "Failed to apply code formatting changes to the repo.",
+                details=exc.stdout,
+            )
 
     def push(self, target, bookmark=None):
         if not os.getenv(REQUEST_USER_ENV_VAR):

--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -464,7 +464,7 @@ class LandingWorker:
                     message = (
                         "Lando failed to format your patch for conformity with our "
                         "formatting policy. Please see the details below.\n\n"
-                        f"{str(exc)}"
+                        f"{exc.details}"
                     )
 
                     logger.exception(message)

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -6,6 +6,10 @@ import enum
 import logging
 import os
 
+from typing import Optional
+
+import flask_sqlalchemy
+
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.dialects.postgresql.json import JSONB
 
@@ -197,7 +201,13 @@ class LandingJob(Base):
 
         return q
 
-    def transition_status(self, action, commit=False, db=None, **kwargs):
+    def transition_status(
+        self,
+        action: str,
+        commit: bool = False,
+        db: Optional[flask_sqlalchemy.SQLAlchemy] = None,
+        **kwargs,
+    ):
         """Change the status and other applicable fields according to actions.
 
         Args:


### PR DESCRIPTION
Add a field to `AutoformattingException` that contains relevant details
for display in failure emails.

Also add type hints to `transition_status` while we are here.
