### PR TITLE
phabricator: remove `g.phabricator` and replace with arguments to command function (Bug 1759890)

### DIFF
--- a/landoapi/api/diff_warnings.py
+++ b/landoapi/api/diff_warnings.py
@@ -14,6 +14,7 @@ import logging
 from connexion import problem
 
 from landoapi.decorators import require_phabricator_api_key
+from landoapi.phabricator import PhabricatorClient
 from landoapi.models.revisions import DiffWarning, DiffWarningStatus
 from landoapi.storage import db
 
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 @require_phabricator_api_key()
-def post(data):
+def post(phab: PhabricatorClient, data: dict):
     """Create a new `DiffWarning` based on provided revision and diff IDs.
 
     Args:
@@ -47,7 +48,7 @@ def post(data):
 
 
 @require_phabricator_api_key()
-def delete(pk):
+def delete(phab: PhabricatorClient, pk: str):
     """Archive a `DiffWarning` based on provided pk."""
     warning = DiffWarning.query.get(pk)
     if not warning:
@@ -63,7 +64,7 @@ def delete(pk):
 
 
 @require_phabricator_api_key()
-def get(revision_id, diff_id, group):
+def get(phab: PhabricatorClient, revision_id: str, diff_id: str, group: str):
     """Return a list of active revision diff warnings, if any."""
     warnings = DiffWarning.query.filter(
         DiffWarning.revision_id == revision_id,

--- a/landoapi/api/diff_warnings.py
+++ b/landoapi/api/diff_warnings.py
@@ -14,15 +14,14 @@ import logging
 from connexion import problem
 
 from landoapi.decorators import require_phabricator_api_key
-from landoapi.phabricator import PhabricatorClient
 from landoapi.models.revisions import DiffWarning, DiffWarningStatus
 from landoapi.storage import db
 
 logger = logging.getLogger(__name__)
 
 
-@require_phabricator_api_key()
-def post(phab: PhabricatorClient, data: dict):
+@require_phabricator_api_key(provide_client=False)
+def post(data: dict):
     """Create a new `DiffWarning` based on provided revision and diff IDs.
 
     Args:
@@ -47,8 +46,8 @@ def post(phab: PhabricatorClient, data: dict):
     return warning.serialize(), 201
 
 
-@require_phabricator_api_key()
-def delete(phab: PhabricatorClient, pk: str):
+@require_phabricator_api_key(provide_client=False)
+def delete(pk: str):
     """Archive a `DiffWarning` based on provided pk."""
     warning = DiffWarning.query.get(pk)
     if not warning:
@@ -63,8 +62,8 @@ def delete(phab: PhabricatorClient, pk: str):
     return warning.serialize(), 200
 
 
-@require_phabricator_api_key()
-def get(phab: PhabricatorClient, revision_id: str, diff_id: str, group: str):
+@require_phabricator_api_key(provide_client=False)
+def get(revision_id: str, diff_id: str, group: str):
     """Return a list of active revision diff warnings, if any."""
     warnings = DiffWarning.query.filter(
         DiffWarning.revision_id == revision_id,

--- a/landoapi/api/revisions.py
+++ b/landoapi/api/revisions.py
@@ -5,11 +5,11 @@
 import logging
 
 from connexion import problem
-from flask import g
 
 from landoapi import auth
 from landoapi.decorators import require_phabricator_api_key
 from landoapi.models import SecApprovalRequest
+from landoapi.phabricator import PhabricatorClient
 from landoapi.projects import get_secure_project_phid
 from landoapi.revisions import revision_is_secure
 from landoapi.secapproval import send_sanitized_commit_message_for_review
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 @auth.require_auth0(scopes=("lando",))
 @require_phabricator_api_key(optional=False)
-def request_sec_approval(data=None):
+def request_sec_approval(phab: PhabricatorClient, data: dict):
     """Update a Revision with a sanitized commit message.
 
     Kicks off the sec-approval process.
@@ -33,8 +33,6 @@ def request_sec_approval(data=None):
             message. e.g. D1234.
         sanitized_message: The sanitized commit message.
     """
-    phab = g.phabricator
-
     revision_id = revision_id_to_int(data["revision_id"])
     alt_message = data["sanitized_message"]
 

--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -5,7 +5,7 @@ import logging
 import urllib.parse
 
 from connexion import problem
-from flask import current_app, g
+from flask import current_app
 from landoapi.commit_message import format_commit_message
 from landoapi.decorators import require_phabricator_api_key
 from landoapi.phabricator import PhabricatorClient, PhabricatorAPIException
@@ -53,17 +53,16 @@ not_found_problem = problem(
 
 
 @require_phabricator_api_key(optional=True)
-def get(revision_id):
+def get(phab: PhabricatorClient, revision_id: str):
     """Get the stack a revision is part of.
 
     Args:
         revision_id: (string) ID of the revision in 'D{number}' format
     """
-    revision_id = revision_id_to_int(revision_id)
+    revision_id_int = revision_id_to_int(revision_id)
 
-    phab = g.phabricator
     revision = phab.call_conduit(
-        "differential.revision.search", constraints={"ids": [revision_id]}
+        "differential.revision.search", constraints={"ids": [revision_id_int]}
     )
     revision = phab.single(revision, "data", none_when_empty=True)
     if revision is None:

--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -225,8 +225,7 @@ def _lock_table_for(
 
 @auth.require_auth0(scopes=("lando", "profile", "email"), userinfo=True)
 @require_phabricator_api_key(optional=True)
-def dryrun(data):
-    phab = g.phabricator
+def dryrun(phab: PhabricatorClient, data: dict):
     landing_path = _parse_transplant_request(data)["landing_path"]
     assessment, *_ = _assess_transplant_request(phab, landing_path)
     return assessment.to_dict()
@@ -234,9 +233,7 @@ def dryrun(data):
 
 @auth.require_auth0(scopes=("lando", "profile", "email"), userinfo=True)
 @require_phabricator_api_key(optional=True)
-def post(data):
-    phab = g.phabricator
-
+def post(phab: PhabricatorClient, data: dict):
     parsed_transplant_request = _parse_transplant_request(data)
     confirmation_token = parsed_transplant_request["confirmation_token"]
     flags = parsed_transplant_request["flags"]
@@ -495,13 +492,12 @@ def post(data):
 
 
 @require_phabricator_api_key(optional=True)
-def get_list(stack_revision_id):
+def get_list(phab: PhabricatorClient, stack_revision_id: str):
     """Return a list of Transplant objects"""
-    revision_id = revision_id_to_int(stack_revision_id)
+    revision_id_int = revision_id_to_int(stack_revision_id)
 
-    phab = g.phabricator
     revision = phab.call_conduit(
-        "differential.revision.search", constraints={"ids": [revision_id]}
+        "differential.revision.search", constraints={"ids": [revision_id_int]}
     )
     revision = phab.single(revision, "data", none_when_empty=True)
     if revision is None:

--- a/landoapi/decorators.py
+++ b/landoapi/decorators.py
@@ -22,9 +22,9 @@ class require_phabricator_api_key:
     If the optional parameter is True and no API key is provided, a default key
     will be used. If an API key is provided it will still be verified.
 
-    Decorated functions may assume X-Phabricator-API-Key header is present,
-    contains a valid phabricator API key and the first argument is a
-    PhabricatorClient using this API Key.
+    Decorated functions may assume X-Phabricator-API-Key header is present and
+    contains a valid phabricator API key. If `provide_client=True`, the first
+    argument is a PhabricatorClient using this API Key.
     """
 
     def __init__(self, optional: bool = False, provide_client: bool = True):

--- a/landoapi/decorators.py
+++ b/landoapi/decorators.py
@@ -27,8 +27,9 @@ class require_phabricator_api_key:
     PhabricatorClient using this API Key.
     """
 
-    def __init__(self, optional=False):
+    def __init__(self, optional: bool = False, provide_client: bool = True):
         self.optional = optional
+        self.provide_client = provide_client
 
     def __call__(self, f):
         @functools.wraps(f)
@@ -58,6 +59,9 @@ class require_phabricator_api_key:
                     type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403",
                 )
 
-            return f(phab, *args, **kwargs)
+            if self.provide_client:
+                return f(phab, *args, **kwargs)
+            else:
+                return f(*args, **kwargs)
 
         return wrapped

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -274,13 +274,13 @@ def warning_revision_secure(*, revision, secure_project_phid, **kwargs):
 
 @RevisionWarningCheck(5, "Revision is missing a Testing Policy Project Tag.")
 def warning_revision_missing_testing_tag(
-    *, revision, testing_tag_project_phids, testing_policy_phid, **kwargs
+    *, revision, repo, testing_tag_project_phids, testing_policy_phid, **kwargs
 ):
     if not testing_tag_project_phids:
         return None
 
     if not revision_needs_testing_tag(
-        revision, testing_tag_project_phids, testing_policy_phid
+        revision, repo, testing_tag_project_phids, testing_policy_phid
     ):
         return None
 

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,6 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
-import flask
 import pytest
 
 from connexion.lifecycle import ConnexionResponse
@@ -10,8 +9,10 @@ from landoapi.decorators import require_phabricator_api_key
 from landoapi.phabricator import PhabricatorClient
 
 
-def noop(*args, **kwargs):
-    return ConnexionResponse(status_code=200)
+def noop(phab, *args, **kwargs):
+    response = ConnexionResponse(status_code=200)
+    response.body = phab
+    return response
 
 
 @pytest.mark.parametrize(
@@ -37,8 +38,8 @@ def test_require_phabricator_api_key(monkeypatch, app, optional, valid_key, stat
     with app.test_request_context("/", headers=headers):
         resp = require_phabricator_api_key(optional=optional)(noop)()
         if status == 200:
-            assert isinstance(flask.g.phabricator, PhabricatorClient)
+            assert isinstance(resp.body, PhabricatorClient)
         if valid_key:
-            assert flask.g.phabricator.api_token == "custom-key"
+            assert resp.body.api_token == "custom-key"
 
     assert resp.status_code == status

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
-from unittest.mock import MagicMock
 
 from landoapi.phabricator import RevisionStatus, ReviewerStatus
 from landoapi.repos import get_repos_for_env
@@ -159,43 +158,28 @@ def test_relman_approval_status(status, phabdouble, release_management_project):
         )
 
 
-def test_revision_does_not_need_testing_tag(phabdouble, monkeypatch):
+def test_revision_does_not_need_testing_tag(phabdouble):
     testing_tag_projects = [{"phid": "testing-tag-phid"}]
     testing_policy_project = {"phid": "testing-policy-phid"}
     repo = phabdouble.repo(projects=[testing_policy_project])
     revision = phabdouble.revision(projects=testing_tag_projects, repo=repo)
-    mock_get_phabricator_repo = MagicMock()
-    mock_get_phabricator_repo.return_value = repo
-    monkeypatch.setattr(
-        "landoapi.revisions.get_phabricator_repo", mock_get_phabricator_repo
-    )
     assert not revision_needs_testing_tag(
-        revision, ["testing-tag-phid"], "testing-policy-phid"
+        revision, repo, ["testing-tag-phid"], "testing-policy-phid"
     )
 
 
-def test_revision_needs_testing_tag(phabdouble, monkeypatch):
+def test_revision_needs_testing_tag(phabdouble):
     testing_policy_project = {"phid": "testing-policy-phid"}
     repo = phabdouble.repo(projects=[testing_policy_project])
     revision = phabdouble.revision(projects=[], repo=repo)
-    mock_get_phabricator_repo = MagicMock()
-    mock_get_phabricator_repo.return_value = repo
-    monkeypatch.setattr(
-        "landoapi.revisions.get_phabricator_repo", mock_get_phabricator_repo
-    )
     assert revision_needs_testing_tag(
-        revision, ["testing-tag-phid"], "testing-policy-phid"
+        revision, repo, ["testing-tag-phid"], "testing-policy-phid"
     )
 
 
-def test_repo_does_not_have_testing_policy(phabdouble, monkeypatch):
+def test_repo_does_not_have_testing_policy(phabdouble):
     repo = phabdouble.repo(projects=[])
     revision = phabdouble.revision(projects=[], repo=repo)
-    mock_get_phabricator_repo = MagicMock()
-    mock_get_phabricator_repo.return_value = repo
-    monkeypatch.setattr(
-        "landoapi.revisions.get_phabricator_repo", mock_get_phabricator_repo
-    )
     assert not revision_needs_testing_tag(
-        revision, ["testing-tag-phid"], "testing-policy-phid"
+        revision, repo, ["testing-tag-phid"], "testing-policy-phid"
     )


### PR DESCRIPTION
Move the `PhabricatorClient` from `g.phabricator` to an argument
passed to the necessary API function. This makes cases where
we require Phabricator more explicit and removes the global
`g.phabricator`, which was inconsistently defined and typed.

In making this change we also notice the `get_phabricator_repo`
usage and function is unnecessary as we have already retrieved
the required `repo` information from Phabricator when the function
is called.

Also rename some variables where we convert between types to
keep each variable name consistently typed.
