### PR TITLE
typing: add/clarify type hints in several places (Bug 1759890)

### DIFF
--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -85,23 +85,30 @@ def get_stats(start_date: str = "", end_date: str = "") -> dict:
         Some meta data and the aggregated statistics.
     """
     if not start_date:
-        start_date = datetime.now()
+        start_date_datetime = datetime.now()
     else:
-        start_date = datetime.fromisoformat(start_date)
+        start_date_datetime = datetime.fromisoformat(start_date)
 
     if not end_date:
-        end_date = datetime.now()
+        end_date_datetime = datetime.now()
     else:
-        end_date = datetime.fromisoformat(end_date)
+        end_date_datetime = datetime.fromisoformat(end_date)
 
-    start_date = start_date.replace(hour=0, minute=0, second=0, microsecond=0)
-    end_date = end_date.replace(hour=23, minute=59, second=59, microsecond=999999)
+    start_date_datetime = start_date_datetime.replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    end_date_datetime = end_date_datetime.replace(
+        hour=23, minute=59, second=59, microsecond=999999
+    )
 
-    if start_date > end_date:
+    if start_date_datetime > end_date_datetime:
         raise ProblemException(
             400,
             "start_date must be on or before end_date.",
-            f"start_date provided: {start_date}, end_date provided: {end_date}.",
+            (
+                f"start_date provided: {start_date_datetime}, "
+                f"end_date provided: {end_date_datetime}."
+            ),
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
@@ -115,8 +122,8 @@ def get_stats(start_date: str = "", end_date: str = "") -> dict:
         )
         .filter(
             LandingJob.status == LandingJobStatus.LANDED,
-            LandingJob.created_at <= end_date,
-            LandingJob.created_at >= start_date,
+            LandingJob.created_at <= end_date_datetime,
+            LandingJob.created_at >= start_date_datetime,
         )
         .group_by("day")
     )

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -72,7 +72,7 @@ def format_commit_message(
     approvals: List[str],
     summary: str,
     revision_url: str,
-    flags: List[str] = None,
+    flags: Optional[List[str]] = None,
 ) -> Tuple[str, str]:
     """
     Creates a default format commit message using revision metadata.

--- a/landoapi/landing_worker.py
+++ b/landoapi/landing_worker.py
@@ -439,8 +439,7 @@ class LandingWorker:
                     return True
                 except Exception as e:
                     message = (
-                        f"Aborting, could not apply patch buffer for {revision_id}, "
-                        f"{diff_id}."
+                        f"Aborting, could not apply patch buffer for {revision_id}."
                     )
                     logger.exception(message)
                     job.transition_status(

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -203,7 +203,7 @@ class LandingJob(Base):
 
     def transition_status(
         self,
-        action: str,
+        action: LandingJobAction,
         commit: bool = False,
         db: Optional[flask_sqlalchemy.SQLAlchemy] = None,
         **kwargs,
@@ -211,7 +211,7 @@ class LandingJob(Base):
         """Change the status and other applicable fields according to actions.
 
         Args:
-            action (str): the action to take, e.g. "land" or "fail"
+            action (LandingJobAction): the action to take, e.g. "land" or "fail"
             commit (bool): whether to commit the changes to the database or not
             db (SQLAlchemy.db): the database to commit to
             **kwargs:

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -57,7 +57,9 @@ def project_search(phabricator, project_phids):
     return result_list_to_phid_dict(phabricator.expect(projects, "data"))
 
 
-def get_project_phid(project_slug, phabricator, allow_empty_result=True):
+def get_project_phid(
+    project_slug: str, phabricator: PhabricatorClient, allow_empty_result: bool = True
+) -> Optional[str]:
     """Looks up a project's PHID.
 
     Args:

--- a/landoapi/revisions.py
+++ b/landoapi/revisions.py
@@ -84,7 +84,7 @@ def serialize_diff(diff):
     }
 
 
-def serialize_status(revision):
+def serialize_status(revision: dict) -> dict:
     status_value = PhabricatorClient.expect(revision, "fields", "status", "value")
     status = RevisionStatus.from_status(status_value)
 
@@ -105,7 +105,7 @@ def serialize_status(revision):
     }
 
 
-def select_diff_author(diff):
+def select_diff_author(diff: dict) -> tuple[Optional[str], Optional[str]]:
     commits = PhabricatorClient.expect(diff, "attachments", "commits", "commits")
     if not commits:
         return None, None
@@ -121,7 +121,7 @@ def get_bugzilla_bug(revision: dict) -> Optional[int]:
     return int(bug) if bug else None
 
 
-def check_diff_author_is_known(*, diff, **kwargs):
+def check_diff_author_is_known(*, diff: dict, **kwargs) -> Optional[str]:
     author_name, author_email = select_diff_author(diff)
     if author_name and author_email:
         return None

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -132,7 +132,7 @@ def request_extended_revision_data(
 
 
 class RevisionStack:
-    def __init__(self, nodes, edges):
+    def __init__(self, nodes: set[str], edges: set[tuple[str, str]]):
         self.nodes = nodes
         self.edges = edges
 


### PR DESCRIPTION
- Add type hints to some functions in `revisions.py`.
- Add type hints to `get_project_phid`.
- Make `flags` kwarg an `Optional`.
- Make `action` a `LandingJobAction` instead of a `str`.
- Remove `diff_id` from base exception handling as it is irrelevant, may be unbound.
- Add `dict` type for list elements in `patch_to_changes`.
- Use a different variable name than `f`, add docstring.
- Add a docstring for `serialize_hunk`.
- Add type hints for `RevisionStack` constructor.
- Fix types for `RevisionStack`.
- Use new variable name for start/end datetimes.
