### PR TITLE
stacks: use phid from stack_data instead of pulling from revision

### DIFF
--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -110,8 +110,7 @@ def get(phab: PhabricatorClient, revision_id: str):
     }
 
     revisions_response = []
-    for _phid, revision in stack_data.revisions.items():
-        revision_phid = PhabricatorClient.expect(revision, "phid")
+    for revision_phid, revision in stack_data.revisions.items():
         fields = PhabricatorClient.expect(revision, "fields")
         diff_phid = PhabricatorClient.expect(fields, "diffPHID")
         repo_phid = PhabricatorClient.expect(fields, "repositoryPHID")


### PR DESCRIPTION
We are already iterating over a dict where each key is the PHID,
so there is no need to pull the PHID from the revision object.
