### PR TITLE
uplift: stop using a `landing_path` for uplift endpoint (Bug 1801926)

### DIFF
--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -391,13 +391,16 @@ paths:
           schema:
             type: object
             required:
-              - landing_path 
+              - revision_id
               - repository
             properties:
               repository:
                 type: string
-              landing_path:
-                $ref: '#/definitions/LandingPath'
+              revision_id:
+                type: string
+                description: |
+                  The ID of a revision in the form of 'D{number}', e.g.
+                  'D12345'.
       responses:
         201:
           description: OK

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 from collections import namedtuple
+from collections.abc import Iterator
 from typing import (
     Callable,
     Iterable,
@@ -141,6 +142,25 @@ class RevisionStack:
         for child, parent in self.edges:
             self.children[parent].add(child)
             self.parents[child].add(parent)
+
+    def base_revisions(self) -> Iterator[str]:
+        """Return the set of base revisions in the stack."""
+        return (node for node in self.nodes if not self.parents[node])
+
+    def iter_stack_from_base(self) -> Iterator[str]:
+        """Iterate over the revisions in the stack starting from the base."""
+        revision = next(self.base_revisions())
+
+        while True:
+            yield revision
+
+            # When there are no children, this will raise `StopIteration`,
+            # which is what we expect `iter_stack_from_base` to raise on
+            # completion as well.
+            try:
+                revision = next(iter(self.children[revision]))
+            except StopIteration:
+                return
 
 
 def calculate_landable_subgraphs(

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -154,9 +154,6 @@ class RevisionStack:
         while True:
             yield revision
 
-            # When there are no children, this will raise `StopIteration`,
-            # which is what we expect `iter_stack_from_base` to raise on
-            # completion as well.
             try:
                 revision = next(iter(self.children[revision]))
             except StopIteration:

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -144,11 +144,26 @@ class RevisionStack:
             self.parents[child].add(parent)
 
     def base_revisions(self) -> Iterator[str]:
-        """Return the set of base revisions in the stack."""
+        """Iterate over the set of base revisions in the stack.
+
+        For example in this stack:
+        A
+        |\
+        B C
+        | |
+        D E
+
+        `set(stack.base_revisions()) == {"D", "E"}`.
+        """
         return (node for node in self.nodes if not self.parents[node])
 
     def iter_stack_from_base(self) -> Iterator[str]:
-        """Iterate over the revisions in the stack starting from the base."""
+        """Iterate over the revisions in the stack starting from the base.
+
+        NOTE: assumes the stack is linear, with one base revision and each
+        subsequent revision having a single child. If there are multiple paths
+        that could be walked in the stack, this function will naively pick one.
+        """
         revision = next(self.base_revisions())
 
         while True:

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -146,7 +146,7 @@ class RevisionStack:
     def base_revisions(self) -> Iterator[str]:
         """Iterate over the set of base revisions in the stack.
 
-        For example in this stack:
+        For example in this stack, where A has no children:
         A
         |\
         B C

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -5,6 +5,7 @@
 from landoapi.phabricator import RevisionStatus
 from landoapi.repos import get_repos_for_env
 from landoapi.stacks import (
+    RevisionStack,
     build_stack_graph,
     calculate_landable_subgraphs,
     get_landable_repos_for_revision_data,
@@ -670,3 +671,20 @@ def test_integrated_stack_has_revision_security_status(
     revisions = {r["phid"]: r for r in response.json["revisions"]}
     assert not revisions[public_revision["phid"]]["is_secure"]
     assert revisions[secure_revision["phid"]]["is_secure"]
+
+
+def test_revisionstack():
+    nodes = ["123", "456", "789"]
+    edges = [("123", "456"), ("456", "789")]
+
+    stack = RevisionStack(nodes, edges)
+
+    assert list(stack.base_revisions()) == [
+        "789"
+    ], "Node `789` should be the base revision."
+
+    assert list(stack.iter_stack_from_base()) == [
+        "789",
+        "456",
+        "123",
+    ], "Iterating over the stack from the base should result in the expected order."


### PR DESCRIPTION
Change the swagger schema for the uplift endpoint to take
a revision ID instead of a landing path. Add simple stack
walking methods to `RevisionStack` and make `get_uplift_conduit_state`
return a `RevisionStack`. Use these stack walking methods in
place of the passed `landing_path` to determine the order
in which to create uplift revisions.
