### PR TITLE
uplift: remove `move_drev_to_original` and instead place line directly from `revision.fields.uri` (Bug 1804508)

### DIFF
--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -44,7 +44,7 @@ MAX_UPLIFT_STACK_SIZE = 5
 UPLIFT_BUG_UPDATE_RETRIES = 3
 
 
-def add_original_revision_line(summary: str, uri: str) -> str:
+def add_original_revision_line_if_needed(summary: str, uri: str) -> str:
     """Return the summary with `Original Revision` added."""
     if any(line.startswith("Original Revision:") for line in summary.splitlines()):
         return summary
@@ -240,7 +240,7 @@ def create_uplift_revision(
     # One may already be present if this revision is being uplift to a
     # second train.
     uri = str(phab.expect(source_revision, "fields", "uri"))
-    summary = add_original_revision_line(summary, uri)
+    summary = add_original_revision_line_if_needed(summary, uri)
 
     transactions = [
         {"type": "update", "value": new_diff_phid},

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -4,7 +4,6 @@
 
 import json
 import logging
-import re
 import time
 
 from packaging.version import (
@@ -42,46 +41,15 @@ logger = logging.getLogger(__name__)
 # Maximum number of revisions allowable in a stack to be auto-uplifted.
 MAX_UPLIFT_STACK_SIZE = 5
 
-ARC_DIFF_REV_RE = re.compile(
-    r"^\s*Differential Revision:\s*(?P<phab_url>https?://.+)/D(?P<rev>\d+)\s*$",
-    flags=re.MULTILINE,
-)
-ORIGINAL_DIFF_REV_RE = re.compile(
-    r"^\s*Original Revision:\s*(?P<phab_url>https?://.+)/D(?P<rev>\d+)\s*$",
-    flags=re.MULTILINE,
-)
-
-
-def move_drev_to_original(body: str) -> str:
-    """Handle moving the `Differential Revision` line.
-
-    Moves the `Differential Revision` line to `Original Revision`, if a link
-    to the original revision does not already exist. If the `Original Revision`
-    line does exist, scrub the `Differential Revision` line.
-
-    Args:
-        body: `str` text of the commit message.
-
-    Returns:
-        New commit message body text as `str`.
-    """
-    differential_revision = ARC_DIFF_REV_RE.search(body)
-    original_revision = ORIGINAL_DIFF_REV_RE.search(body)
-
-    # If both match, we already have an `Original Revision` line.
-    if differential_revision and original_revision:
-        return body
-
-    def repl(match):
-        phab_url = match.group("phab_url")
-        rev = match.group("rev")
-        return f"\nOriginal Revision: {phab_url}/D{rev}"
-
-    # Update the commit message.
-    return ARC_DIFF_REV_RE.sub(repl, body)
-
-
 UPLIFT_BUG_UPDATE_RETRIES = 3
+
+
+def add_original_revision_line(summary: str, uri: str) -> str:
+    """Return the summary with `Original Revision` added."""
+    if any(line.startswith("Original Revision:") for line in summary.splitlines()):
+        return summary
+
+    return f"{summary}\n\nOriginal Revision: {uri}"
 
 
 def parse_milestone_version(milestone_contents: str) -> Version:
@@ -266,9 +234,13 @@ def create_uplift_revision(
         ),
     )
 
-    # Update `Differential Revision` to `Original Revision`.
     summary = str(phab.expect(source_revision, "fields", "summary"))
-    summary = move_drev_to_original(summary)
+
+    # Add a link to the original revision if one isn't already present.
+    # One may already be present if this revision is being uplift to a
+    # second train.
+    uri = str(phab.expect(source_revision, "fields", "uri"))
+    summary = add_original_revision_line(summary, uri)
 
     transactions = [
         {"type": "update", "value": new_diff_phid},

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -11,7 +11,7 @@ from packaging.version import (
 from landoapi.phabricator import PhabricatorClient
 from landoapi.stacks import build_stack_graph
 from landoapi.uplift import (
-    add_original_revision_line,
+    add_original_revision_line_if_needed,
     create_uplift_bug_update_payload,
     parse_milestone_version,
 )
@@ -316,7 +316,7 @@ def test_create_uplift_bug_update_payload():
     ), "Status should not have been set with `leave-open` keyword on bug."
 
 
-def test_add_original_revision_line():
+def test_add_original_revision_line_if_needed():
     uri = "http://phabricator.test/D123"
 
     summary_no_original = "Bug 123: test summary r?sheehan"
@@ -327,9 +327,11 @@ def test_add_original_revision_line():
     )
 
     assert (
-        add_original_revision_line(summary_no_original, uri) == summary_with_original
+        add_original_revision_line_if_needed(summary_no_original, uri)
+        == summary_with_original
     ), "Passing summary without `Original Revision` should return with line added."
 
     assert (
-        add_original_revision_line(summary_with_original, uri) == summary_with_original
+        add_original_revision_line_if_needed(summary_with_original, uri)
+        == summary_with_original
     ), "Passing summary with `Original Revision` should return the input."

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -11,8 +11,8 @@ from packaging.version import (
 from landoapi.phabricator import PhabricatorClient
 from landoapi.stacks import build_stack_graph
 from landoapi.uplift import (
+    add_original_revision_line,
     create_uplift_bug_update_payload,
-    move_drev_to_original,
     parse_milestone_version,
 )
 
@@ -61,35 +61,6 @@ def test_parse_milestone_version():
     bad_milestone_contents = "blahblahblah"
     with pytest.raises(ValueError, match=bad_milestone_contents):
         parse_milestone_version(bad_milestone_contents)
-
-
-def test_move_drev_to_original():
-    # Ensure `Differential Revision` is moved to `Original`.
-    commit_message = (
-        "bug 1: title r?reviewer\n"
-        "\n"
-        "Differential Revision: http://phabricator.test/D1"
-    )
-    expected = (
-        "bug 1: title r?reviewer\n\nOriginal Revision: http://phabricator.test/D1"
-    )
-    message = move_drev_to_original(commit_message)
-    assert (
-        message == expected
-    ), "`Differential Revision` not re-written to `Original Revision` on uplift."
-
-    # Ensure `Original` and `Differential` in commit message is left unchanged.
-    commit_message = (
-        "bug 1: title r?reviewer\n"
-        "\n"
-        "Original Revision: http://phabricator.test/D1\n"
-        "\n"
-        "Differential Revision: http://phabricator.test/D2"
-    )
-    message = move_drev_to_original(commit_message)
-    assert (
-        message == commit_message
-    ), "Commit message should not have changed when original revision already present."
 
 
 @pytest.mark.xfail
@@ -343,3 +314,22 @@ def test_create_uplift_bug_update_payload():
     assert (
         "cf_status_firefox100" not in payload
     ), "Status should not have been set with `leave-open` keyword on bug."
+
+
+def test_add_original_revision_line():
+    uri = "http://phabricator.test/D123"
+
+    summary_no_original = "Bug 123: test summary r?sheehan"
+    summary_with_original = (
+        "Bug 123: test summary r?sheehan\n"
+        "\n"
+        "Original Revision: http://phabricator.test/D123"
+    )
+
+    assert (
+        add_original_revision_line(summary_no_original, uri) == summary_with_original
+    ), "Passing summary without `Original Revision` should return with line added."
+
+    assert (
+        add_original_revision_line(summary_with_original, uri) == summary_with_original
+    ), "Passing summary with `Original Revision` should return the input."


### PR DESCRIPTION
The `summary` field in Phabricator does not include the
`Differential Revision` line, so `move_drev_to_original`
effectively does nothing. Instead place the value of
`revision.fields.uri` in the summary as `Original Revision`
directly.
