### PR TITLE
stacks: attach `projects` for repos in `request_extended_revision_data` (Bug 1805265)

### DIFF
--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -121,6 +121,7 @@ def request_extended_revision_data(
     if repo_phids:
         repos = phab.call_conduit(
             "diffusion.repository.search",
+            attachments={"projects": True},
             constraints={"phids": [phid for phid in repo_phids]},
             limit=len(repo_phids),
         )

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1242,7 +1242,11 @@ class PhabricatorDouble:
                         "policy": i["policy"],
                         "defaultBranch": i["defaultBranch"],
                     },
-                    "attachments": {},
+                    "attachments": {
+                        attachment: i["attachments"][attachment]
+                        for attachment, value in attachments.items()
+                        if value is True and attachment in i["attachments"]
+                    },
                 }
             )
 

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -251,6 +251,21 @@ def test_request_extended_revision_data_stacked_revisions(phabdouble):
     assert repo["phid"] in data.repositories
 
 
+def test_request_extended_revision_data_repo_has_projects(phabdouble, secure_project):
+    phab = phabdouble.get_phabricator_client()
+
+    repo = phabdouble.repo(projects=[secure_project])
+
+    diff1 = phabdouble.diff(repo=repo)
+    r1 = phabdouble.revision(diff=diff1, repo=repo)
+
+    data = request_extended_revision_data(phab, [r1["phid"]])
+
+    assert all(
+        "projects" in repo["attachments"] for repo in data.repositories.values()
+    ), "`request_extended_revision_data` should return repos with `projects` attachment."
+
+
 def test_calculate_landable_subgraphs_no_edges_open(phabdouble):
     phab = phabdouble.get_phabricator_client()
 


### PR DESCRIPTION
In https://github.com/mozilla-conduit/lando-api/pull/236 I removed an
unnecessary call to `diffusion.repository.search` as we were already doing
a search for the same repo earlier in the program logic and passing the
returned object into the check. After removing and deploying this call,
Lando started failing when trying to access the projects attachment on
the repo object. This is because the call to `diffusion.repository.search`
doesn't include the projects attachment parameter.

We need to add `projects: True` to the `diffusion.repository.search` call
so the projects data is available.
