### PR TITLE
uplift: return repo `shortName` instead of `name` (Bug 1805695)

### DIFF
--- a/landoapi/api/uplift.py
+++ b/landoapi/api/uplift.py
@@ -26,7 +26,8 @@ logger = logging.getLogger(__name__)
 def get(phab: PhabricatorClient):
     """Return the list of valid uplift repositories."""
     repos = [
-        phab.expect(repo, "fields", "name") for repo in get_uplift_repositories(phab)
+        phab.expect(repo, "fields", "shortName")
+        for repo in get_uplift_repositories(phab)
     ]
 
     return {"repos": repos}, 201


### PR DESCRIPTION
Repos are mapped by "shortName: Repo()" in `repos.py` and
thus the value we need to return from the `GET` endpoint
is the `shortName`.
