### PR TITLE
projects: remove `get_relman_phid` in favor of `get_release_managers` (Bug 1806455)

### DIFF
--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -10,9 +10,9 @@ from landoapi.commit_message import format_commit_message
 from landoapi.decorators import require_phabricator_api_key
 from landoapi.phabricator import PhabricatorClient, PhabricatorAPIException
 from landoapi.projects import (
+    get_release_managers,
     get_sec_approval_project_phid,
     get_secure_project_phid,
-    get_relman_group_phid,
     project_search,
 )
 from landoapi.repos import get_repos_for_env
@@ -38,7 +38,6 @@ from landoapi.stacks import (
     request_extended_revision_data,
 )
 from landoapi.transplants import get_blocker_checks
-from landoapi.uplift import get_release_managers
 from landoapi.users import user_search
 from landoapi.validation import revision_id_to_int
 
@@ -79,8 +78,14 @@ def get(phab: PhabricatorClient, revision_id: str):
     supported_repos = get_repos_for_env(current_app.config.get("ENVIRONMENT"))
     landable_repos = get_landable_repos_for_revision_data(stack_data, supported_repos)
 
+    release_managers = get_release_managers(phab)
+    if not release_managers:
+        raise Exception("Could not find `#release-managers` project on Phabricator.")
+
+    relman_group_phid = str(phab.expect(release_managers, "phid"))
+
     other_checks = get_blocker_checks(
-        relman_group_phid=get_relman_group_phid(phab),
+        relman_group_phid=relman_group_phid,
         repositories=supported_repos,
         stack_data=stack_data,
     )
@@ -103,7 +108,6 @@ def get(phab: PhabricatorClient, revision_id: str):
 
     secure_project_phid = get_secure_project_phid(phab)
     sec_approval_project_phid = get_sec_approval_project_phid(phab)
-    release_managers = get_release_managers(phab)
     relman_phids = {
         member["phid"]
         for member in release_managers["attachments"]["members"]["members"]

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -38,7 +38,7 @@ SEC_APPROVAL_CACHE_KEY = "sec-approval-project-phid"
 # The name of the Phabricator project containing members of the Release
 # Management team, to approve uplift requests
 RELMAN_PROJECT_SLUG = "release-managers"
-RELMAN_CACHE_KEY = "release-managers-project-phid"
+RELMAN_CACHE_KEY = "release-managers-project"
 
 
 def project_search(phabricator, project_phids):
@@ -139,6 +139,11 @@ def get_sec_approval_project_phid(phabricator: PhabricatorClient) -> Optional[st
 
 
 @cache.cached(key_prefix=RELMAN_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT_SECONDS)
-def get_relman_group_phid(phabricator: PhabricatorClient) -> Optional[str]:
-    """Return a phid for the relman group's project."""
-    return get_project_phid(RELMAN_PROJECT_SLUG, phabricator)
+def get_release_managers(phab: PhabricatorClient) -> dict:
+    """Load the release-managers group details from Phabricator"""
+    groups = phab.call_conduit(
+        "project.search",
+        attachments={"members": True},
+        constraints={"slugs": [RELMAN_PROJECT_SLUG]},
+    )
+    return phab.single(groups, "data")

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -24,7 +24,6 @@ from landoapi import bmo
 from landoapi.cache import cache, DEFAULT_CACHE_KEY_TIMEOUT_SECONDS
 from landoapi.phabricator import PhabricatorClient, PhabricatorAPIException
 from landoapi.phabricator_patch import patch_to_changes
-from landoapi.projects import RELMAN_PROJECT_SLUG
 from landoapi.repos import (
     Repo,
     get_repos_for_env,
@@ -84,16 +83,6 @@ def get_uplift_repositories(phab: PhabricatorClient) -> list:
     repos = phab.expect(repos, "data")
 
     return repos
-
-
-def get_release_managers(phab: PhabricatorClient) -> dict:
-    """Load the release-managers group details from Phabricator"""
-    groups = phab.call_conduit(
-        "project.search",
-        attachments={"members": True},
-        constraints={"slugs": [RELMAN_PROJECT_SLUG]},
-    )
-    return phab.single(groups, "data")
 
 
 def get_revisions_without_bugs(phab: PhabricatorClient, revisions: dict) -> set[str]:

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -26,7 +26,9 @@ from landoapi.transplants import (
 )
 
 
-def test_dryrun_no_warnings_or_blockers(client, db, phabdouble, auth0_mock):
+def test_dryrun_no_warnings_or_blockers(
+    client, db, phabdouble, auth0_mock, release_management_project
+):
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=phabdouble.repo())
     phabdouble.reviewer(r1, phabdouble.user(username="reviewer"))
@@ -48,7 +50,9 @@ def test_dryrun_no_warnings_or_blockers(client, db, phabdouble, auth0_mock):
     assert response.json == expected_json
 
 
-def test_dryrun_invalid_path_blocks(client, db, phabdouble, auth0_mock):
+def test_dryrun_invalid_path_blocks(
+    client, db, phabdouble, auth0_mock, release_management_project
+):
     d1 = phabdouble.diff()
     d2 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=phabdouble.repo())
@@ -74,7 +78,9 @@ def test_dryrun_invalid_path_blocks(client, db, phabdouble, auth0_mock):
     assert response.json["blocker"] is not None
 
 
-def test_dryrun_in_progress_transplant_blocks(client, db, phabdouble, auth0_mock):
+def test_dryrun_in_progress_transplant_blocks(
+    client, db, phabdouble, auth0_mock, release_management_project
+):
     repo = phabdouble.repo()
 
     # Structure:
@@ -120,7 +126,9 @@ def test_dryrun_in_progress_transplant_blocks(client, db, phabdouble, auth0_mock
     )
 
 
-def test_dryrun_reviewers_warns(client, db, phabdouble, auth0_mock):
+def test_dryrun_reviewers_warns(
+    client, db, phabdouble, auth0_mock, release_management_project
+):
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=phabdouble.repo())
     phabdouble.reviewer(
@@ -152,6 +160,7 @@ def test_dryrun_codefreeze_warn(
     codefreeze_datetime,
     monkeypatch,
     request_mocker,
+    release_management_project,
 ):
     product_details = "https://product-details.mozilla.org/1.0/firefox_versions.json"
     request_mocker.register_uri(
@@ -209,6 +218,7 @@ def test_dryrun_outside_codefreeze(
     codefreeze_datetime,
     monkeypatch,
     request_mocker,
+    release_management_project,
 ):
     product_details = "https://product-details.mozilla.org/1.0/firefox_versions.json"
     request_mocker.register_uri(
@@ -270,7 +280,14 @@ def test_dryrun_outside_codefreeze(
     ],
 )
 def test_integrated_dryrun_blocks_for_bad_userinfo(
-    client, db, auth0_mock, phabdouble, userinfo, status, blocker
+    client,
+    db,
+    auth0_mock,
+    phabdouble,
+    userinfo,
+    status,
+    blocker,
+    release_management_project,
 ):
     auth0_mock.userinfo = userinfo
     d1 = phabdouble.diff()
@@ -663,7 +680,7 @@ def test_integrated_transplant_with_flags(
 
 
 def test_integrated_transplant_with_invalid_flags(
-    db, client, phabdouble, s3, auth0_mock, monkeypatch
+    db, client, phabdouble, s3, auth0_mock, monkeypatch, release_management_project
 ):
     repo = phabdouble.repo(name="mozilla-new")
     user = phabdouble.user(username="reviewer")
@@ -761,7 +778,7 @@ def test_integrated_transplant_repo_checkin_project_removed(
 
 
 def test_integrated_transplant_without_auth0_permissions(
-    client, auth0_mock, phabdouble, db
+    client, auth0_mock, phabdouble, db, release_management_project
 ):
     auth0_mock.userinfo = CANNED_USERINFO["NO_CUSTOM_CLAIMS"]
 
@@ -904,7 +921,7 @@ def test_transplant_wrong_landing_path_format(db, client, auth0_mock):
 
 
 def test_integrated_transplant_diff_not_in_revision(
-    db, client, phabdouble, s3, auth0_mock
+    db, client, phabdouble, s3, auth0_mock, release_management_project
 ):
     repo = phabdouble.repo()
     d1 = phabdouble.diff()
@@ -926,7 +943,7 @@ def test_integrated_transplant_diff_not_in_revision(
 
 
 def test_transplant_nonexisting_revision_returns_404(
-    db, client, phabdouble, auth0_mock
+    db, client, phabdouble, auth0_mock, release_management_project
 ):
     response = client.post(
         "/transplants",
@@ -939,7 +956,7 @@ def test_transplant_nonexisting_revision_returns_404(
 
 
 def test_integrated_transplant_revision_with_no_repo(
-    db, client, phabdouble, auth0_mock
+    db, client, phabdouble, auth0_mock, release_management_project
 ):
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1)
@@ -961,7 +978,7 @@ def test_integrated_transplant_revision_with_no_repo(
 
 
 def test_integrated_transplant_revision_with_unmapped_repo(
-    db, client, phabdouble, auth0_mock
+    db, client, phabdouble, auth0_mock, release_management_project
 ):
     repo = phabdouble.repo(name="notsupported")
     d1 = phabdouble.diff()


### PR DESCRIPTION
In a few places within Lando-API we retrieve the `#release-managers`
group information. In some cases we only require a PHID and in some
cases we need the entire group information. When we need each, we
make a call to the Conduit API to get the required info.

Consolidate these two use cases into one function that returns all
information for the `release-managers` project, eliminating the extra
calls to Conduit. Move `get_release_managers` to `projects.py` where
it makes more sense and cache it for efficiency.

Add the `release_management_project` fixture to `test_transplants.py`
tests where it is needed.
