### PR TITLE
autoformat: deduplicate bug IDs in commit message (Bug 1808090)

### DIFF
--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -207,4 +207,4 @@ def bug_list_to_commit_string(bug_ids: list[str]) -> str:
     if not bug_ids:
         return "No bug"
 
-    return f"Bug {', '.join(bug_ids)}"
+    return f"Bug {', '.join(sorted(set(bug_ids)))}"

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -215,3 +215,6 @@ def test_bug_list_to_commit_string():
     assert (
         bug_list_to_commit_string(["123", "456"]) == "Bug 123, 456"
     ), "Multiple bugs should return comma separated list."
+    assert (
+        bug_list_to_commit_string(["123", "123"]) == "Bug 123"
+    ), "Multiple bugs should be deduplicated."


### PR DESCRIPTION
You can see an example of the problem at https://hg.mozilla.org/mozilla-central/rev/1b3d211c35998c7a277d40b8a01c242e45a1223a

Previously the commit message would be like "Bug 1790368, 1790368, 1790368: apply code formatting via Lando".