### PR TITLE
typing: fix a few typing issues (Bug 1759890)

### DIFF
--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -91,7 +91,7 @@ def get(phab: PhabricatorClient, revision_id: str):
     )
 
     landable, blocked = calculate_landable_subgraphs(
-        stack_data, edges, set(landable_repos), other_checks=other_checks
+        stack_data, edges, landable_repos, other_checks=other_checks
     )
     uplift_repos = [
         name for name, repo in supported_repos.items() if repo.approval_required

--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -91,7 +91,7 @@ def get(phab: PhabricatorClient, revision_id: str):
     )
 
     landable, blocked = calculate_landable_subgraphs(
-        stack_data, edges, landable_repos, other_checks=other_checks
+        stack_data, edges, set(landable_repos), other_checks=other_checks
     )
     uplift_repos = [
         name for name, repo in supported_repos.items() if repo.approval_required
@@ -107,7 +107,11 @@ def get(phab: PhabricatorClient, revision_id: str):
     projects = project_search(phab, involved_phids)
 
     secure_project_phid = get_secure_project_phid(phab)
+
     sec_approval_project_phid = get_sec_approval_project_phid(phab)
+    if not sec_approval_project_phid:
+        raise Exception("Could not find `#sec-approval` project on Phabricator.")
+
     relman_phids = {
         member["phid"]
         for member in release_managers["attachments"]["members"]["members"]

--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -143,7 +143,7 @@ def _assess_transplant_request(phab, landing_path, relman_group_phid):
     )
 
     landable, blocked = calculate_landable_subgraphs(
-        stack_data, edges, set(landable_repos), other_checks=other_checks
+        stack_data, edges, landable_repos, other_checks=other_checks
     )
 
     assessment = check_landing_blockers(

--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -143,7 +143,7 @@ def _assess_transplant_request(phab, landing_path, relman_group_phid):
     )
 
     landable, blocked = calculate_landable_subgraphs(
-        stack_data, edges, landable_repos, other_checks=other_checks
+        stack_data, edges, set(landable_repos), other_checks=other_checks
     )
 
     assessment = check_landing_blockers(

--- a/landoapi/phabricator.py
+++ b/landoapi/phabricator.py
@@ -334,7 +334,9 @@ class PhabricatorCommunicationException(PhabricatorAPIException):
     """Exception when communicating with Phabricator fails."""
 
 
-def result_list_to_phid_dict(result_list, *, phid_key="phid"):
+def result_list_to_phid_dict(
+    result_list: list[dict], *, phid_key: str = "phid"
+) -> dict[str, dict]:
     """Return a dictionary mapping phid to items from a result list.
 
     Args:

--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -56,7 +56,7 @@ ReviewerIdentity = namedtuple("ReviewerIdentity", ("identifier", "full_name"))
 
 
 def reviewer_identity(
-    phid: str, user_search_data: list[dict], project_search_data: list[dict]
+    phid: str, user_search_data: dict, project_search_data: dict
 ) -> ReviewerIdentity:
     if phid in user_search_data:
         return ReviewerIdentity(
@@ -151,7 +151,7 @@ def serialize_reviewers(
 
 
 def reviewers_for_commit_message(
-    reviewers: dict, users: List[dict], projects: List[dict], sec_approval_phid: str
+    reviewers: dict, users: dict, projects: dict, sec_approval_phid: str
 ) -> List[str]:
     """Turn a list of reviewer objects into a list of reviewer names.
 
@@ -159,8 +159,8 @@ def reviewers_for_commit_message(
 
     Args:
         reviewers: Dict of {reviewer_phid: reviewer_data}
-        users: List of Phabricator Users that were involved in the revision.
-        projects: List of Phabricator Projects that were involved in the revision.
+        users: Dict of Phabricator Users that were involved in the revision.
+        projects: Dict of Phabricator Projects that were involved in the revision.
         sec_approval_phid: The PHID string of the sec-approval project.
 
     Returns:

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -3,7 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 from collections import namedtuple
-from collections.abc import Iterator
+from collections.abc import (
+    Container,
+    Iterator,
+)
 from typing import (
     Callable,
     Iterable,
@@ -179,7 +182,7 @@ class RevisionStack:
 def calculate_landable_subgraphs(
     revision_data: RevisionData,
     edges: set[tuple[str, str]],
-    landable_repos: set[str],
+    landable_repos: Container[str],
     *,
     other_checks: Iterable[Callable[[dict, dict, dict], Optional[str]]] = []
 ) -> tuple[list[list[str]], dict[str, str]]:
@@ -191,7 +194,7 @@ def calculate_landable_subgraphs(
         edges: a set of tuples (child, parent) each representing an edge
             between two nodes. `child` and `parent` are also string
             PHIDs.
-        landable_repos: a set of string PHIDs for repositories that
+        landable_repos: a container of string PHIDs for repositories that
             are supported for landing.
         other_checks: An iterable of callables which will be executed
             for each revision to determine if it should be blocked. These

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -58,7 +58,7 @@ def test_check_author_planned_changes_changes_planned(phabdouble):
 
 
 def test_secure_api_flag_on_public_revision_is_false(
-    db, client, phabdouble, release_management_project
+    db, client, phabdouble, release_management_project, sec_approval_project
 ):
     repo = phabdouble.repo(name="test-repo")
     public_project = phabdouble.project("public")
@@ -72,7 +72,12 @@ def test_secure_api_flag_on_public_revision_is_false(
 
 
 def test_secure_api_flag_on_secure_revision_is_true(
-    db, client, phabdouble, secure_project, release_management_project
+    db,
+    client,
+    phabdouble,
+    secure_project,
+    release_management_project,
+    sec_approval_project,
 ):
     repo = phabdouble.repo(name="test-repo")
     revision = phabdouble.revision(projects=[secure_project], repo=repo)

--- a/tests/test_sanitized_commit_messages.py
+++ b/tests/test_sanitized_commit_messages.py
@@ -85,6 +85,7 @@ def test_integrated_secure_stack_has_alternate_commit_message(
     authed_headers,
     monkeypatch,
     release_management_project,
+    sec_approval_project,
 ):
     sanitized_title = "my secure commit title"
     revision_title = "my insecure revision title"
@@ -112,7 +113,13 @@ def test_integrated_secure_stack_has_alternate_commit_message(
 
 
 def test_integrated_secure_stack_without_sec_approval_does_not_use_secure_message(
-    db, client, phabdouble, mock_repo_config, secure_project, release_management_project
+    db,
+    client,
+    phabdouble,
+    mock_repo_config,
+    secure_project,
+    release_management_project,
+    sec_approval_project,
 ):
     # Build a plain old secure revision, no sec-approval requests made.
     secure_revision = phabdouble.revision(

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -611,7 +611,12 @@ def test_get_landable_repos_for_revision_data(phabdouble, mocked_repo_config):
 
 
 def test_integrated_stack_endpoint_simple(
-    db, client, phabdouble, mocked_repo_config, release_management_project
+    db,
+    client,
+    phabdouble,
+    mocked_repo_config,
+    release_management_project,
+    sec_approval_project,
 ):
     repo = phabdouble.repo()
     unsupported_repo = phabdouble.repo(name="not-mozilla-central")
@@ -646,7 +651,12 @@ def test_integrated_stack_endpoint_simple(
 
 
 def test_integrated_stack_endpoint_repos(
-    db, client, phabdouble, mocked_repo_config, release_management_project
+    db,
+    client,
+    phabdouble,
+    mocked_repo_config,
+    release_management_project,
+    sec_approval_project,
 ):
     repo = phabdouble.repo()
     unsupported_repo = phabdouble.repo(name="not-mozilla-central")
@@ -672,7 +682,13 @@ def test_integrated_stack_endpoint_repos(
 
 
 def test_integrated_stack_has_revision_security_status(
-    db, client, phabdouble, mock_repo_config, secure_project, release_management_project
+    db,
+    client,
+    phabdouble,
+    mock_repo_config,
+    secure_project,
+    release_management_project,
+    sec_approval_project,
 ):
     repo = phabdouble.repo()
     public_revision = phabdouble.revision(repo=repo)


### PR DESCRIPTION
- Pass `landable_repos` as a `set` instead of a `dict`.
- Add types for `result_list_to_phid_dict`.
- Fix types for some functions in `reviewer_identity`.
- Add a `None` check for `sec_approval_project_phid` and add
  add sec-approval project to tests where it is needed.
