### PR TITLE
transplants: add warning for revisions with unresolved comments (Bug 1504720)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -199,6 +199,7 @@ def _assess_transplant_request(
     }
 
     assessment = check_landing_warnings(
+        phab,
         g.auth0_user,
         to_land,
         repo,

--- a/landoapi/models/revisions.py
+++ b/landoapi/models/revisions.py
@@ -35,7 +35,7 @@ class DiffWarningGroup(enum.Enum):
 class DiffWarning(Base):
     """Represents a warning message associated with a particular diff and revision."""
 
-    # A Phabricator revision and diff ID (NOTE: revision ID does not inlude a prefix.)
+    # A Phabricator revision and diff ID (NOTE: revision ID does not include a prefix.)
     revision_id = db.Column(db.Integer, nullable=False)
     diff_id = db.Column(db.Integer, nullable=False)
 

--- a/landoapi/transactions.py
+++ b/landoapi/transactions.py
@@ -74,7 +74,9 @@ def get_raw_comments(transaction):
     ]
 
 
-def get_inline_comments(phab: PhabricatorClient, object_identifer: str) -> filter:
+def get_inline_comments(
+    phab: PhabricatorClient, object_identifer: str
+) -> Iterator[Transaction]:
     """Returns an iterable of inline comments for the requested object.
 
     Args:

--- a/landoapi/transactions.py
+++ b/landoapi/transactions.py
@@ -72,3 +72,17 @@ def get_raw_comments(transaction):
         PhabricatorClient.expect(comment, "content", "raw")
         for comment in PhabricatorClient.expect(transaction, "comments")
     ]
+
+
+def get_inline_comments(phab: PhabricatorClient, object_identifer: str) -> filter:
+    """Returns an iterable of inline comments for the requested object.
+
+    Args:
+        phab: A PhabricatorClient instance.
+        object_identifer: An object identifier (PHID or monogram) whose inline
+            comments we want to fetch.
+    """
+    return filter(
+        lambda transaction: transaction["type"] == "inline",
+        transaction_search(phab, object_identifer),
+    )

--- a/landoapi/transactions.py
+++ b/landoapi/transactions.py
@@ -77,7 +77,7 @@ def get_raw_comments(transaction):
 def get_inline_comments(
     phab: PhabricatorClient, object_identifer: str
 ) -> Iterator[Transaction]:
-    """Returns an iterable of inline comments for the requested object.
+    """Returns an iterator of inline comments for the requested object.
 
     Args:
         phab: A PhabricatorClient instance.

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -358,10 +358,10 @@ def warning_code_freeze(*, repo, **kwargs):
 
 @RevisionWarningCheck(9, "Revision has unresolved comments.")
 def warning_unresolved_comments(*, phab, revision, **kwargs):
-    if False in [
-        PhabricatorClient.expect(inline, "fields", "isDone")
+    if not all(
+        phab.expect(inline, "fields", "isDone")
         for inline in get_inline_comments(phab, f"D{revision['id']}")
-    ]:
+    ):
         return "Revision has unresolved comments."
 
 

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -27,6 +27,7 @@ from landoapi.revisions import (
 from landoapi.stacks import (
     RevisionData,
 )
+from landoapi.transactions import get_inline_comments
 
 logger = logging.getLogger(__name__)
 
@@ -355,6 +356,15 @@ def warning_code_freeze(*, repo, **kwargs):
         ]
 
 
+@RevisionWarningCheck(9, "Revision has unresolved comments.")
+def warning_unresolved_comments(*, phab, revision, **kwargs):
+    if False in [
+        PhabricatorClient.expect(inline, "fields", "isDone")
+        for inline in get_inline_comments(phab, f"D{revision['id']}")
+    ]:
+        return "Revision has unresolved comments."
+
+
 def user_block_no_auth0_email(*, auth0_user, **kwargs):
     """Check the user has a proper auth0 email."""
     return (
@@ -379,6 +389,7 @@ def user_block_scm_level(*, auth0_user, landing_repo, **kwargs):
 
 
 def check_landing_warnings(
+    phab,
     auth0_user,
     to_land,
     repo,
@@ -400,12 +411,14 @@ def check_landing_warnings(
         warning_diff_warning,
         warning_wip_commit_message,
         warning_code_freeze,
+        warning_unresolved_comments,
     ],
 ):
     assessment = TransplantAssessment()
     for revision, diff in to_land:
         for check in revision_warnings:
             result = check(
+                phab=phab,
                 revision=revision,
                 diff=diff,
                 repo=repo,

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -567,7 +567,12 @@ class PhabricatorDouble:
         return project
 
     def transaction(
-        self, transaction_type: str, object: dict, operations=None, comments=None
+        self,
+        transaction_type: str,
+        object: dict,
+        operations=None,
+        comments=None,
+        fields=None,
     ):
         """Return a Phabricator Transaction object.
 
@@ -585,13 +590,15 @@ class PhabricatorDouble:
             comments: Optional list of comment objects this transaction created. Only
                 applies when the transaction type is "comment" or "inline". Structure
                 varies greatly depending on the comment type.
+            fields: Optional dictionary of fields attached to the transaction. Fields
+                vary depending on the transaction type.
 
         """
         # Pull out what type of object we are operating on: DREV? PROJ?
         object_type = object["type"]
         object_phid = object["phid"]
         comments = comments or []
-        fields = {}
+        fields = fields or {}
 
         if operations:
             fields["operations"] = operations
@@ -1357,7 +1364,7 @@ class PhabricatorDouble:
             # type of transaction they are using and make sure it is serialized
             # correctly by this function.
             txn_type = i["type"]
-            if txn_type not in ("comment", "dummy", "reviewers.add"):
+            if txn_type not in ("comment", "dummy", "reviewers.add", "inline"):
                 raise ValueError(
                     "PhabricatorDouble transactions do not have support "
                     'for the "{}" transaction type. '

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -2,7 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from landoapi.transactions import get_raw_comments, transaction_search
+from landoapi.transactions import (
+    get_inline_comments,
+    get_raw_comments,
+    transaction_search,
+)
 
 
 def test_transaction_search_for_all_transactions(phabdouble):
@@ -68,3 +72,18 @@ def test_find_transaction_by_phid(phabdouble):
     txn = phabdouble.transaction("dummy", revision)
     phid = revision["phid"]
     assert list(transaction_search(phab, phid)) == [txn]
+
+
+def test_get_inline_comments(phabdouble):
+    phab = phabdouble.get_phabricator_client()
+    revision = phabdouble.revision()
+    txn = phabdouble.transaction(
+        transaction_type="inline",
+        object=revision,
+        comments=["this is done"],
+        fields={"isDone": True},
+    )
+    phabdouble.transaction("dummy", revision)
+    name = f"D{revision['id']}"
+
+    assert list(get_inline_comments(phab, name)) == [txn]

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -83,6 +83,7 @@ def test_get_inline_comments(phabdouble):
         comments=["this is done"],
         fields={"isDone": True},
     )
+    # get_inline_comments should filter out unrelated transaction types.
     phabdouble.transaction("dummy", revision)
     name = f"D{revision['id']}"
 

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1165,7 +1165,8 @@ def test_unresolved_comment_stack(
     auth0_mock,
     release_management_project,
 ):
-    """Ensure a warning is generated when a revision in the stack has unresolved comments.
+    """
+    Ensure a warning is generated when a revision in the stack has unresolved comments.
 
     This test sets up a stack and adds a transaction to each revision, including
     unresolved comments and a dummy transaction.

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1165,8 +1165,7 @@ def test_unresolved_comment_stack(
     auth0_mock,
     release_management_project,
 ):
-    """Ensure a warning is generated when a revision in the stack has unresolved
-    comments.
+    """Ensure a warning is generated when a revision in the stack has unresolved comments.
 
     This test sets up a stack and adds a transaction to each revision, including
     unresolved comments and a dummy transaction.

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1094,6 +1094,15 @@ def test_unresolved_comment_warn(
     auth0_mock,
     release_management_project,
 ):
+    """Ensure a warning is generated when a revision has unresolved comments.
+
+    This test sets up a revision and adds a resolved comment and dummy
+    transaction. Sending a request should not generate a warning at this
+    stage.
+
+    Adding an unresolved comment and making the request again should
+    generate a warning.
+    """
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=phabdouble.repo())
     phabdouble.reviewer(r1, phabdouble.user(username="reviewer"))
@@ -1103,7 +1112,7 @@ def test_unresolved_comment_warn(
         comments=["this is done"],
         fields={"isDone": True},
     )
-    # Function should filter out unrelated transaction types.
+    # get_inline_comments should filter out unrelated transaction types.
     phabdouble.transaction("dummy", r1)
 
     response = client.post(
@@ -1156,6 +1165,12 @@ def test_unresolved_comment_stack(
     auth0_mock,
     release_management_project,
 ):
+    """Ensure a warning is generated when a revision in the stack has unresolved
+    comments.
+
+    This test sets up a stack and adds a transaction to each revision, including
+    unresolved comments and a dummy transaction.
+    """
     repo = phabdouble.repo()
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=repo)
@@ -1190,7 +1205,7 @@ def test_unresolved_comment_stack(
         fields={"isDone": True},
     )
 
-    # Function should filter out unrelated transaction types.
+    # get_inline_comments should filter out unrelated transaction types.
     phabdouble.transaction("dummy", r3)
 
     response = client.post(


### PR DESCRIPTION
[Bug 1504720 - Require confirmation when a revision has unresolved comments](https://bugzilla.mozilla.org/show_bug.cgi?id=1504720)
- right now if a revision has unresolved comments in the stack, that information is not surfaced to the user
- adds a warning which will check the transactions for the revisions in `to_land` and determine if any of the inline comments are still unresolved