### PR TITLE
transactions: remove unused `get_raw_comments` (Bug 1809730)

### DIFF
--- a/landoapi/transactions.py
+++ b/landoapi/transactions.py
@@ -1,8 +1,14 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 """Functions for working with Phabricator transactions."""
-from typing import Iterator, NewType
+
+from typing import (
+    Iterator,
+    NewType,
+    Optional,
+)
 
 from landoapi.phabricator import PhabricatorClient
 
@@ -14,7 +20,10 @@ Comment = NewType("Comment", dict)
 
 
 def transaction_search(
-    phabricator, object_identifier, transaction_phids=None, limit=100
+    phabricator: PhabricatorClient,
+    object_identifier: str,
+    transaction_phids: Optional[list[str]] = None,
+    limit: int = 100,
 ) -> Iterator[Transaction]:
     """Yield the Phabricator transactions related to an object.
 
@@ -58,17 +67,3 @@ def transaction_search(
         if next_page_start is None:
             # This was the last page of results.
             return
-
-
-def get_raw_comments(transaction):
-    """Return a list of 'raw' comment bodies in a Phabricator transaction.
-
-    A single transaction can have multiple comment bodies: e.g. a top-level comment
-    and a couple of inline comments along with it.
-
-    See https://phabricator.services.mozilla.com/conduit/method/transaction.search/.
-    """
-    return [
-        PhabricatorClient.expect(comment, "content", "raw")
-        for comment in PhabricatorClient.expect(transaction, "comments")
-    ]

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from landoapi.transactions import get_raw_comments, transaction_search
+from landoapi.transactions import transaction_search
 
 
 def test_transaction_search_for_all_transactions(phabdouble):
@@ -42,16 +42,6 @@ def test_paginated_transactions_are_fetched_too(phabdouble):
     # Limit the retrieved page size to force multiple API calls.
     transactions = list(transaction_search(phab, revision["phid"], limit=1))
     assert transactions == new_transactions
-
-
-def test_add_comments_to_revision_generates_transactions(phabdouble):
-    phab = phabdouble.get_phabricator_client()
-    comments = ["yes!", "no?", "~wobble~"]
-    revision = phabdouble.revision(comments=[phabdouble.comment(c) for c in comments])
-    transactions = list(transaction_search(phab, revision["phid"]))
-    txn_comments = [get_raw_comments(t).pop() for t in transactions]
-    assert len(transactions) == len(comments)
-    assert txn_comments == comments
 
 
 def test_find_transaction_by_object_name(phabdouble):


### PR DESCRIPTION
Remove `get_raw_comments` as it is an unused function.
While we're here also add type hints to the other functions
in this file.
