### PR TITLE
api, models: finish adding type hints, make `ConfigurationKey` a proper enum (Bug 1759890)

### DIFF
--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @auth.require_auth0(scopes=("lando", "profile", "email"), userinfo=True)
-def put(landing_job_id, data):
+def put(landing_job_id: str, data: dict):
     """Update a landing job.
 
     Checks whether the logged in user is allowed to modify the landing job that is
@@ -24,7 +24,7 @@ def put(landing_job_id, data):
     instance accordingly.
 
     Args:
-        landing_job_id (int): The unique ID of the LandingJob object.
+        landing_job_id (str): The unique ID of the LandingJob object.
         data (dict): A dictionary containing the cleaned data payload from the request.
 
     Raises:

--- a/landoapi/api/landings.py
+++ b/landoapi/api/landings.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 @auth.require_transplant_authentication
-def update(data):
+def update(data: dict):
     """Update landing on pingback from Transplant.
 
     data contains following fields:

--- a/landoapi/decorators.py
+++ b/landoapi/decorators.py
@@ -3,6 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import functools
 
+from typing import (
+    Callable,
+)
+
 from connexion import problem, request
 from flask import current_app
 
@@ -31,7 +35,7 @@ class require_phabricator_api_key:
         self.optional = optional
         self.provide_client = provide_client
 
-    def __call__(self, f):
+    def __call__(self, f: Callable) -> Callable:
         @functools.wraps(f)
         def wrapped(*args, **kwargs):
             api_key = request.headers.get("X-Phabricator-API-Key")

--- a/landoapi/models/base.py
+++ b/landoapi/models/base.py
@@ -29,7 +29,7 @@ class Base(db.Model):
     )
 
     @declared_attr
-    def __tablename__(self):
+    def __tablename__(self) -> str:
         """Return a snake-case version of the class name as the table name.
 
         To override __tablename__, define this attribute as needed on your
@@ -37,7 +37,7 @@ class Base(db.Model):
         """
         return table_name_re.sub(r"_\1", self.__name__).lower()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return a human-readable representation of the instance.
 
         For example, `<Transplant: 1235>`.

--- a/landoapi/models/configuration.py
+++ b/landoapi/models/configuration.py
@@ -15,7 +15,7 @@ from landoapi.storage import db
 
 logger = logging.getLogger(__name__)
 
-ConfigurationValue = Union[bool, int, str]
+ConfigurationValueType = Union[bool, int, str]
 
 
 class ConfigurationKey:
@@ -42,7 +42,7 @@ class ConfigurationVariable(Base):
     variable_type = db.Column(db.Enum(VariableType), default=VariableType.STR)
 
     @property
-    def value(self) -> ConfigurationValue:
+    def value(self) -> ConfigurationValueType:
         """The parsed value of `raw_value` based on `variable_type`.
 
         Returns:
@@ -70,7 +70,7 @@ class ConfigurationVariable(Base):
 
     @classmethod
     @cache.memoize()
-    def get(cls, key: str, default: ConfigurationValue) -> ConfigurationValue:
+    def get(cls, key: str, default: ConfigurationValueType) -> ConfigurationValueType:
         """Fetch a variable using `key`, return `default` if it does not exist.
 
         Returns: The parsed value of the configuration variable, of type `str`, `int`,
@@ -81,8 +81,8 @@ class ConfigurationVariable(Base):
 
     @classmethod
     def set(
-        cls, key: str, variable_type: VariableType, raw_value: ConfigurationValue
-    ) -> Optional[ConfigurationValue]:
+        cls, key: str, variable_type: VariableType, raw_value: ConfigurationValueType
+    ) -> Optional[ConfigurationValueType]:
         """Set a variable `key` of type `variable_type` and value `raw_value`.
 
         Returns:

--- a/landoapi/models/configuration.py
+++ b/landoapi/models/configuration.py
@@ -4,11 +4,18 @@
 import enum
 import logging
 
+from typing import (
+    Optional,
+    Union,
+)
+
 from landoapi.cache import cache
 from landoapi.models.base import Base
 from landoapi.storage import db
 
 logger = logging.getLogger(__name__)
+
+ConfigurationValue = Union[bool, int, str]
 
 
 class ConfigurationKey:
@@ -35,7 +42,7 @@ class ConfigurationVariable(Base):
     variable_type = db.Column(db.Enum(VariableType), default=VariableType.STR)
 
     @property
-    def value(self):
+    def value(self) -> ConfigurationValue:
         """The parsed value of `raw_value` based on `variable_type`.
 
         Returns:
@@ -59,9 +66,11 @@ class ConfigurationVariable(Base):
         elif self.variable_type == VariableType.STR:
             return self.raw_value
 
+        raise ValueError("Could not parse raw value for configuration variable.")
+
     @classmethod
     @cache.memoize()
-    def get(cls, key, default):
+    def get(cls, key: str, default: ConfigurationValue) -> ConfigurationValue:
         """Fetch a variable using `key`, return `default` if it does not exist.
 
         Returns: The parsed value of the configuration variable, of type `str`, `int`,
@@ -71,7 +80,9 @@ class ConfigurationVariable(Base):
         return record.value if record else default
 
     @classmethod
-    def set(cls, key, variable_type, raw_value):
+    def set(
+        cls, key: str, variable_type: VariableType, raw_value: ConfigurationValue
+    ) -> Optional[ConfigurationValue]:
         """Set a variable `key` of type `variable_type` and value `raw_value`.
 
         Returns:

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -6,12 +6,17 @@ import enum
 import logging
 import os
 
-from typing import Optional
+from typing import (
+    Any,
+    Optional,
+    Iterable,
+)
 
 import flask_sqlalchemy
 
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.dialects.postgresql.json import JSONB
+from sqlalchemy.orm import Query
 
 from landoapi.models.base import Base
 from landoapi.storage import db
@@ -141,11 +146,11 @@ class LandingJob(Base):
     formatted_replacements = db.Column(JSONB, nullable=True)
 
     @property
-    def landing_path(self):
+    def landing_path(self) -> list[tuple[int, int]]:
         return [(int(r), self.revision_to_diff_id[r]) for r in self.revision_order]
 
     @property
-    def head_revision(self):
+    def head_revision(self) -> str:
         """Human-readable representation of the branch head's Phabricator revision ID."""
         assert (
             self.revision_order
@@ -153,12 +158,16 @@ class LandingJob(Base):
         return "D" + self.revision_order[-1]
 
     @classmethod
-    def revisions_query(cls, revisions):
+    def revisions_query(cls, revisions: Iterable[str]) -> Query:
         revisions = [str(int(r)) for r in revisions]
         return cls.query.filter(cls.revision_to_diff_id.has_any(array(revisions)))
 
     @classmethod
-    def job_queue_query(cls, repositories=None, grace_seconds=DEFAULT_GRACE_SECONDS):
+    def job_queue_query(
+        cls,
+        repositories: Optional[Iterable[str]] = None,
+        grace_seconds: int = DEFAULT_GRACE_SECONDS,
+    ) -> Query:
         """Return a query which selects the queued jobs.
 
         Args:
@@ -191,15 +200,15 @@ class LandingJob(Base):
         return q
 
     @classmethod
-    def next_job_for_update_query(cls, repositories=None):
+    def next_job_for_update_query(cls, repositories: Optional[str] = None) -> Query:
         """Return a query which selects the next job and locks the row."""
-        q = cls.job_queue_query(repositories=repositories)
+        query = cls.job_queue_query(repositories=repositories)
 
         # Returned rows should be locked for updating, this ensures the next
         # job can be claimed.
-        q = q.with_for_update()
+        query = query.with_for_update()
 
-        return q
+        return query
 
     def transition_status(
         self,
@@ -259,7 +268,7 @@ class LandingJob(Base):
         if commit:
             db.session.commit()
 
-    def serialize(self):
+    def serialize(self) -> dict[str, Any]:
         """Return a JSON compatible dictionary."""
         return {
             "id": self.id,

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -16,7 +16,6 @@ import flask_sqlalchemy
 
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.dialects.postgresql.json import JSONB
-from sqlalchemy.orm import Query
 
 from landoapi.models.base import Base
 from landoapi.storage import db
@@ -158,7 +157,7 @@ class LandingJob(Base):
         return "D" + self.revision_order[-1]
 
     @classmethod
-    def revisions_query(cls, revisions: Iterable[str]) -> Query:
+    def revisions_query(cls, revisions: Iterable[str]) -> flask_sqlalchemy.BaseQuery:
         revisions = [str(int(r)) for r in revisions]
         return cls.query.filter(cls.revision_to_diff_id.has_any(array(revisions)))
 
@@ -167,7 +166,7 @@ class LandingJob(Base):
         cls,
         repositories: Optional[Iterable[str]] = None,
         grace_seconds: int = DEFAULT_GRACE_SECONDS,
-    ) -> Query:
+    ) -> flask_sqlalchemy.BaseQuery:
         """Return a query which selects the queued jobs.
 
         Args:
@@ -200,7 +199,9 @@ class LandingJob(Base):
         return q
 
     @classmethod
-    def next_job_for_update_query(cls, repositories: Optional[str] = None) -> Query:
+    def next_job_for_update_query(
+        cls, repositories: Optional[str] = None
+    ) -> flask_sqlalchemy.BaseQuery:
         """Return a query which selects the next job and locks the row."""
         query = cls.job_queue_query(repositories=repositories)
 

--- a/landoapi/models/secapproval.py
+++ b/landoapi/models/secapproval.py
@@ -32,7 +32,7 @@ class SecApprovalRequest(Base):
     comment_candidates = db.Column(JSONB, nullable=False)
 
     @classmethod
-    def build(cls, revision, transactions):
+    def build(cls, revision: dict, transactions: list[dict]) -> "SecApprovalRequest":
         """Build a `SecApprovalRequest` object for a transaction list.
 
         Args:
@@ -56,7 +56,7 @@ class SecApprovalRequest(Base):
         )
 
     @classmethod
-    def most_recent_request_for_revision(cls, revision) -> "SecApprovalRequest":
+    def most_recent_request_for_revision(cls, revision: dict) -> "SecApprovalRequest":
         """Return the most recent sec-approval request for a Phabricator Revision."""
         return (
             cls.query.filter_by(revision_id=revision["id"])

--- a/landoapi/models/transplant.py
+++ b/landoapi/models/transplant.py
@@ -7,9 +7,10 @@ import logging
 
 from typing import Any
 
+import flask_sqlalchemy
+
 from sqlalchemy.dialects.postgresql import array
 from sqlalchemy.dialects.postgresql.json import JSONB
-from sqlalchemy.orm import Query
 
 from landoapi.models.base import Base
 from landoapi.storage import db
@@ -102,7 +103,7 @@ class Transplant(Base):
         return "D" + self.revision_order[-1]
 
     @classmethod
-    def revisions_query(cls, revisions: list[str]) -> Query:
+    def revisions_query(cls, revisions: list[str]) -> flask_sqlalchemy.BaseQuery:
         revisions = [str(int(r)) for r in revisions]
         return cls.query.filter(cls.revision_to_diff_id.has_any(array(revisions)))
 


### PR DESCRIPTION
Finish adding type hints to all modules in `api/` and `models/`.

Type hints for `put` are updated from `int` to `str` to reflect
the correct state in `swagger.yml`.

Add a type alias for configuration values that is an alias to
`bool | int | str`. Also raise at the end of the function to
avoid an accidental `None` return in some edge cases.
Convert `ConfigurationKey` to a proper `Enum` type, add
type hints for it and convert usages of it's underlying `str`
to use the `.value` attribute.

Add `flask_sqlalchemy.BaseQuery` as the return type for
model queries.
