### PR TITLE
typing: remove `typing.{Dict,List,Set,Tuple,Union}` and use builtins directly (Bug 1759890)

### DIFF
--- a/landoapi/auth.py
+++ b/landoapi/auth.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+from __future__ import annotations
+
 import functools
 import hashlib
 import hmac
@@ -13,7 +15,6 @@ from collections.abc import Iterable
 from typing import (
     Callable,
     Optional,
-    Union,
 )
 
 import requests
@@ -586,7 +587,7 @@ def require_transplant_authentication(f: Callable) -> Callable:
 class Auth0Subsystem(Subsystem):
     name = "auth0"
 
-    def ready(self) -> Union[bool, str]:
+    def ready(self) -> bool | str:
         domain = self.flask_app.config.get("OIDC_DOMAIN")
         identifier = self.flask_app.config.get("OIDC_IDENTIFIER")
 
@@ -604,7 +605,7 @@ class Auth0Subsystem(Subsystem):
 
         return True
 
-    def healthy(self) -> Union[bool, str]:
+    def healthy(self) -> bool | str:
         try:
             get_jwks()
         except ProblemException as exc:

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -3,7 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Add revision data to commit message."""
 import re
-from typing import List, Optional, Tuple
+
+from typing import (
+    Optional,
+)
 
 REVISION_URL_TEMPLATE = "Differential Revision: {url}"
 
@@ -67,12 +70,12 @@ METADATA_RE = re.compile("^MozReview-Commit-ID: ")
 def format_commit_message(
     title: str,
     bug: Optional[int],
-    reviewers: List[str],
-    approvals: List[str],
+    reviewers: list[str],
+    approvals: list[str],
     summary: str,
     revision_url: str,
-    flags: Optional[List[str]] = None,
-) -> Tuple[str, str]:
+    flags: Optional[list[str]] = None,
+) -> tuple[str, str]:
     """
     Creates a default format commit message using revision metadata.
 
@@ -187,7 +190,7 @@ def replace_reviewers(
         return commit_summary.strip() + "\n" + commit_description
 
 
-def split_title_and_summary(msg: str) -> Tuple[str, str]:
+def split_title_and_summary(msg: str) -> tuple[str, str]:
     """Split a VCS commit message into its title and body.
 
     Returns a tuple of (title, summary) strings. The summary string may be empty.
@@ -199,7 +202,7 @@ def split_title_and_summary(msg: str) -> Tuple[str, str]:
     return title, summary
 
 
-def bug_list_to_commit_string(bug_ids: List[str]) -> str:
+def bug_list_to_commit_string(bug_ids: list[str]) -> str:
     """Convert a list of `str` bug IDs to a string for a commit message."""
     if not bug_ids:
         return "No bug"

--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -13,7 +13,7 @@ import uuid
 
 from contextlib import contextmanager
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import hglib
 
@@ -217,7 +217,7 @@ class HgRepo:
             configs=self._config_to_list(),
         )
 
-    def run_hg(self, args: List[str]) -> bytes:
+    def run_hg(self, args: list[str]) -> bytes:
         correlation_id = str(uuid.uuid4())
         logger.info(
             "running hg command",
@@ -259,7 +259,7 @@ class HgRepo:
 
         return out
 
-    def run_hg_cmds(self, cmds: List[List[str]]) -> bytes:
+    def run_hg_cmds(self, cmds: list[list[str]]) -> bytes:
         last_result = b""
         for cmd in cmds:
             try:
@@ -409,7 +409,7 @@ class HgRepo:
             ]
         )
 
-    def run_mach_command(self, args: List[str]) -> str:
+    def run_mach_command(self, args: list[str]) -> str:
         """Run a command using the local `mach`, raising if it is missing."""
         if not self.mach_path:
             raise Exception("No `mach` found in local repo!")
@@ -450,7 +450,7 @@ class HgRepo:
 
             raise exc
 
-    def format_stack_amend(self) -> Optional[List[str]]:
+    def format_stack_amend(self) -> Optional[list[str]]:
         """Amend the top commit in the patch stack with changes from formatting."""
         try:
             # Amend the current commit, using `--no-edit` to keep the existing commit message.
@@ -464,7 +464,7 @@ class HgRepo:
 
             raise exc
 
-    def format_stack_tip(self, bug_ids: List[str]) -> Optional[List[str]]:
+    def format_stack_tip(self, bug_ids: list[str]) -> Optional[list[str]]:
         """Add an autoformat commit to the top of the patch stack.
 
         Return the commit hash of the autoformat commit as a `str`,
@@ -492,7 +492,7 @@ class HgRepo:
 
             raise exc
 
-    def format_stack(self, stack_size: int, bug_ids: List[str]) -> Optional[List[str]]:
+    def format_stack(self, stack_size: int, bug_ids: list[str]) -> Optional[list[str]]:
         """Format the patch stack for landing.
 
         Return a list of `str` commit hashes where autoformatting was applied,

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import logging
 
-from typing import Optional, List
+from typing import Optional
 
 from landoapi.cache import cache, DEFAULT_CACHE_KEY_TIMEOUT_SECONDS
 from landoapi.phabricator import result_list_to_phid_dict, PhabricatorClient
@@ -117,7 +117,7 @@ def get_testing_policy_phid(phabricator: PhabricatorClient) -> Optional[str]:
 )
 def get_testing_tag_project_phids(
     phabricator: PhabricatorClient,
-) -> Optional[List[str]]:
+) -> Optional[list[str]]:
     """Return phids for the testing tag projects."""
     tags = [get_project_phid(slug, phabricator) for slug in TESTING_TAG_PROJ_SLUGS]
     return [t for t in tags if t is not None]

--- a/landoapi/reviews.py
+++ b/landoapi/reviews.py
@@ -4,7 +4,6 @@
 
 import logging
 from collections import namedtuple
-from typing import List, Tuple
 
 from landoapi.phabricator import (
     PhabricatorClient,
@@ -152,7 +151,7 @@ def serialize_reviewers(
 
 def reviewers_for_commit_message(
     reviewers: dict, users: dict, projects: dict, sec_approval_phid: str
-) -> List[str]:
+) -> list[str]:
     """Turn a list of reviewer objects into a list of reviewer names.
 
     The list holds reviewers that accepted the revision.
@@ -177,11 +176,11 @@ def reviewers_for_commit_message(
 
 def approvals_for_commit_message(
     reviewers: dict,
-    users: List[dict],
-    projects: List[dict],
-    relman_phids: List[dict],
-    accepted_reviewers: List[str],
-) -> Tuple[List[str], List[str]]:
+    users: list[dict],
+    projects: list[dict],
+    relman_phids: list[dict],
+    accepted_reviewers: list[str],
+) -> tuple[list[str], list[str]]:
     """Turn a list of reviewer objects into a list of approval names.
 
     The list holds release managers that approved the revision, to be re-written as

--- a/landoapi/stacks.py
+++ b/landoapi/stacks.py
@@ -10,10 +10,7 @@ from collections.abc import (
 from typing import (
     Callable,
     Iterable,
-    List,
     Optional,
-    Set,
-    Tuple,
 )
 
 from landoapi.repos import Repo
@@ -28,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def build_stack_graph(
     phab: PhabricatorClient, revision_phid: str
-) -> Tuple[Set[str], Set[Tuple[str, str]]]:
+) -> tuple[set[str], set[tuple[str, str]]]:
     """Return a graph representation of a revision stack.
 
     This function is expensive and can make up to approximately
@@ -83,7 +80,7 @@ RevisionData = namedtuple("RevisionData", ("revisions", "diffs", "repositories")
 
 
 def request_extended_revision_data(
-    phab: PhabricatorClient, revision_phids: List[str]
+    phab: PhabricatorClient, revision_phids: list[str]
 ) -> RevisionData:
     """Return a RevisionData containing extended data for revisions.
 

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -13,7 +13,6 @@ from packaging.version import (
 from typing import (
     Any,
     Optional,
-    Tuple,
 )
 
 import requests
@@ -100,7 +99,7 @@ def get_revisions_without_bugs(phab: PhabricatorClient, revisions: dict) -> set[
 
 def get_uplift_conduit_state(
     phab: PhabricatorClient, revision_id: int, target_repository_name: str
-) -> Tuple[RevisionData, RevisionStack, dict]:
+) -> tuple[RevisionData, RevisionStack, dict]:
     """Queries Conduit for repository and stack information about the requested uplift.
 
     Gathers information about:


### PR DESCRIPTION
Since we are on modern Python we can use builtins
for type hints. Also remove usages of `Union`
in favor of separating values with `|`.
