### PR TITLE
typing: add missing types to `auth.py` and `cli.py` (Bug 1759890)

### DIFF
--- a/landoapi/auth.py
+++ b/landoapi/auth.py
@@ -270,7 +270,7 @@ class A0User:
 
     _GROUPS_CLAIM_KEY = "https://sso.mozilla.com/claim/groups"
 
-    def __init__(self, access_token, userinfo):
+    def __init__(self, access_token: str, userinfo: dict):
         self.access_token = access_token
 
         # We should discourage touching userinfo directly
@@ -500,7 +500,7 @@ class require_auth0:
         return self._require_access_token(f)
 
 
-def _not_authorized_problem_exception():
+def _not_authorized_problem_exception() -> ProblemException:
     return ProblemException(
         403,
         "Not Authorized",

--- a/landoapi/cli.py
+++ b/landoapi/cli.py
@@ -7,7 +7,6 @@ import sys
 
 from typing import (
     Optional,
-    Type,
 )
 
 import click
@@ -28,7 +27,7 @@ from landoapi.systems import Subsystem
 LINT_PATHS = ("setup.py", "tasks.py", "landoapi", "migrations", "tests")
 
 
-def get_subsystems(exclude: Optional[list[Type[Subsystem]]] = None):
+def get_subsystems(exclude: Optional[list[Subsystem]] = None) -> list[Subsystem]:
     """Get subsystems from the app, excluding those specified in the given parameter.
 
     Args:


### PR DESCRIPTION
We don't need the `Type` specifier for `get_subsystems`,
we can just use `Subsystem`. Also add a return type for
the function.

Add types where they are missing from `auth.py`.
