### PR TITLE
uplift: check `target_repo` for `None` (Bug 1759890)

### DIFF
--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -116,6 +116,9 @@ def get_uplift_conduit_state(
     )
     target_repo = phab.single(target_repo, "data")
 
+    if not target_repo:
+        raise ValueError(f"Could not find uplift target repo {target_repository_name}")
+
     # Load base revision details from Phabricator
     revision = phab.call_conduit(
         "differential.revision.search", constraints={"ids": [revision_id]}


### PR DESCRIPTION
Technically this can be `None`, so we should check
it to avoid problems down the line.
