### PR TITLE
projects: clarify that `get_release_managers` returns an `Optional` (Bug 1759890)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -258,7 +258,11 @@ def post(phab: PhabricatorClient, data: dict):
             "flags": flags,
         },
     )
+
     release_managers = get_release_managers(phab)
+    if not release_managers:
+        raise Exception("Could not find `#release-managers` project on Phabricator.")
+
     relman_group_phid = phab.expect(release_managers, "phid")
 
     assessment, to_land, landing_repo, stack_data = _assess_transplant_request(

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -41,7 +41,9 @@ RELMAN_PROJECT_SLUG = "release-managers"
 RELMAN_CACHE_KEY = "release-managers-project"
 
 
-def project_search(phabricator, project_phids):
+def project_search(
+    phabricator: PhabricatorClient, project_phids: list[str]
+) -> dict[str, dict]:
     """Return a dictionary mapping phid to project data from a project.search.
 
     Args:
@@ -139,7 +141,7 @@ def get_sec_approval_project_phid(phabricator: PhabricatorClient) -> Optional[st
 
 
 @cache.cached(key_prefix=RELMAN_CACHE_KEY, timeout=DEFAULT_CACHE_KEY_TIMEOUT_SECONDS)
-def get_release_managers(phab: PhabricatorClient) -> dict:
+def get_release_managers(phab: PhabricatorClient) -> Optional[dict]:
     """Load the release-managers group details from Phabricator"""
     groups = phab.call_conduit(
         "project.search",


### PR DESCRIPTION
Add an `Optional` type around `get_release_managers`, since it
returns the value of `phab.single` which is not confirmed to
exist. Add a `None`-check to locations where we assume it is
available.

While we're here also add a type hint to `project_search` as
it is missing one.
