### PR TITLE
types: add type hints to `secapproval.py`, `sentry.py`, `transplant_client.py` (Bug 1759890)

### DIFF
--- a/landoapi/secapproval.py
+++ b/landoapi/secapproval.py
@@ -47,7 +47,9 @@ class CommitDescription(NamedTuple):
     sanitized: bool
 
 
-def send_sanitized_commit_message_for_review(revision_phid, message, phabclient):
+def send_sanitized_commit_message_for_review(
+    revision_phid: str, message: str, phab: PhabricatorClient
+) -> list[dict]:
     """Send a sanitized commit message for review by the sec-approval team.
 
     See https://wiki.mozilla.org/Security/Bug_Approval_Process.
@@ -62,8 +64,8 @@ def send_sanitized_commit_message_for_review(revision_phid, message, phabclient)
         sec-approval request.
     """
     comment = SECURE_COMMENT_TEMPLATE.format(message=message)
-    sec_approval_phid = get_sec_approval_project_phid(phabclient)
-    response = phabclient.call_conduit(
+    sec_approval_phid = get_sec_approval_project_phid(phab)
+    response = phab.call_conduit(
         "differential.revision.edit",
         objectIdentifier=revision_phid,
         transactions=[
@@ -86,7 +88,7 @@ def send_sanitized_commit_message_for_review(revision_phid, message, phabclient)
             {"type": "reviewers.add", "value": [f"blocking({sec_approval_phid})"]},
         ],
     )
-    return PhabricatorClient.expect(response, "transactions")
+    return phab.expect(response, "transactions")
 
 
 def search_sec_approval_request_for_comment(

--- a/landoapi/sentry.py
+++ b/landoapi/sentry.py
@@ -11,14 +11,14 @@ from landoapi.systems import Subsystem
 logger = logging.getLogger(__name__)
 
 
-def sanitize_headers(headers):
+def sanitize_headers(headers: dict):
     sensitive_keys = ("X-PHABRICATOR-API-KEY",)
     for key in headers:
         if key.upper() in sensitive_keys:
             headers[key] = 10 * "*"
 
 
-def before_send(event, *args):
+def before_send(event: dict, *args) -> dict:
     if "request" in event and "headers" in event["request"]:
         sanitize_headers(event["request"]["headers"])
     return event

--- a/landoapi/transplant_client.py
+++ b/landoapi/transplant_client.py
@@ -1,10 +1,15 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import annotations
+
 import json
 import logging
 import os
+
 from random import randint
+from typing import Optional
 
 import requests
 
@@ -17,14 +22,20 @@ logger = logging.getLogger(__name__)
 class TransplantClient:
     """A class to interface with Transplant's API."""
 
-    def __init__(self, transplant_url, username, password):
+    def __init__(self, transplant_url: str, username: str, password: str):
         self.transplant_url = transplant_url
         self.username = username
         self.password = password
 
     def land(
-        self, revision_id, ldap_username, patch_urls, tree, pingback, push_bookmark=""
-    ):
+        self,
+        revision_id: int,
+        ldap_username: str,
+        patch_urls: list[str],
+        tree: str,
+        pingback: str,
+        push_bookmark: str = "",
+    ) -> Optional[int]:
         """Sends a POST request to Transplant API to land a patch
 
         Args:
@@ -107,14 +118,14 @@ class TransplantClient:
     def _submit_landing_request(
         self,
         *,
-        ldap_username,
-        tree,
-        rev,
-        patch_urls,
-        destination,
-        pingback_url,
-        push_bookmark
-    ):
+        ldap_username: str,
+        tree: str,
+        rev: str,
+        patch_urls: list[str],
+        destination: str,
+        pingback_url: str,
+        push_bookmark: str,
+    ) -> requests.Response:
         logger.info(
             "Initiating transplant landing request",
             extra={
@@ -151,7 +162,7 @@ class TransplantClient:
         )
         return response
 
-    def ping(self):
+    def ping(self) -> requests.Response:
         """Make a GET request to Transplant to check connectivity."""
         return requests.get(url=self.transplant_url)
 
@@ -163,7 +174,7 @@ class TransplantError(Exception):
 class TransplantSubsystem(Subsystem):
     name = "transplant"
 
-    def ready(self):
+    def ready(self) -> bool | str:
         # Protect against enabling pingback without proper security. If
         # we're allowing pingbacks but the api key is None or empty abort:
         if self.flask_app.config.get(
@@ -173,7 +184,7 @@ class TransplantSubsystem(Subsystem):
 
         return True
 
-    def healthy(self):
+    def healthy(self) -> bool | str:
         tc = TransplantClient(
             self.flask_app.config.get("TRANSPLANT_URL"),
             self.flask_app.config.get("TRANSPLANT_USERNAME"),


### PR DESCRIPTION
Also rename `phabclient` to `phab` to match the usual Lando convention.
