### PR TITLE
uplift: make Bugzilla status tracking flag configurable per-repo (Bug 1825091)

### DIFF
--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -54,6 +54,8 @@ class Repo:
         approval_required (bool): Whether approval is required or not for given repo.
             Note that this is not fully implemented but is included for compatibility.
             Defaults to `False`.
+        milestone_tracking_flag_template (str): A format string that takes the current
+            release milestone and returns the relevant Bugzilla status tracking flag.
         commit_flags (list of tuple): A list of supported flags that can be appended to
             the commit message at landing time (e.g. `[("DONTBUILD", "help text")]`).
         product_details_url (str): The URL which contains product-related information
@@ -68,6 +70,7 @@ class Repo:
     pull_path: str = ""
     short_name: str = ""
     approval_required: bool = False
+    milestone_tracking_flag_template: str = ""
     autoformat_enabled: bool = False
     commit_flags: list[tuple[str, str]] = field(default_factory=list)
     product_details_url: str = ""
@@ -180,6 +183,7 @@ REPO_CONFIG = {
             push_path="ssh://autoland.hg//repos/third-repo",
             pull_path="http://hg.test/third-repo",
             approval_required=True,
+            milestone_tracking_flag_template="cf_status_firefox{milestone}",
         ),
         # Approval is required for the uplift dev repo
         "uplift-target": Repo(
@@ -187,6 +191,7 @@ REPO_CONFIG = {
             url="http://hg.test",  # TODO: fix this? URL is probably incorrect.
             access_group=SCM_LEVEL_1,
             approval_required=True,
+            milestone_tracking_flag_template="cf_status_firefox{milestone}",
         ),
     },
     "devsvcdev": {
@@ -201,6 +206,7 @@ REPO_CONFIG = {
             access_group=SCM_CONDUIT,
             commit_flags=[DONTBUILD],
             approval_required=True,
+            milestone_tracking_flag_template="cf_status_firefox{milestone}",
             product_details_url="https://raw.githubusercontent.com/mozilla-conduit"
             "/suite/main/docker/product-details/1.0/firefox_versions.json",
         ),
@@ -300,6 +306,7 @@ REPO_CONFIG = {
             url="https://hg.mozilla.org/releases/mozilla-beta",
             access_group=SCM_ALLOW_DIRECT_PUSH,
             approval_required=True,
+            milestone_tracking_flag_template="cf_status_firefox{milestone}",
             commit_flags=[DONTBUILD],
         ),
         "release": Repo(
@@ -308,6 +315,7 @@ REPO_CONFIG = {
             url="https://hg.mozilla.org/releases/mozilla-release",
             access_group=SCM_ALLOW_DIRECT_PUSH,
             approval_required=True,
+            milestone_tracking_flag_template="cf_status_firefox{milestone}",
             commit_flags=[DONTBUILD],
         ),
         "esr102": Repo(
@@ -316,6 +324,7 @@ REPO_CONFIG = {
             url="https://hg.mozilla.org/releases/mozilla-esr102",
             access_group=SCM_ALLOW_DIRECT_PUSH,
             approval_required=True,
+            milestone_tracking_flag_template="cf_status_firefox_esr{milestone}",
             commit_flags=[DONTBUILD],
         ),
     },

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -305,7 +305,7 @@ def stack_uplift_form_submitted(stack_data: RevisionData) -> bool:
 
 
 def create_uplift_bug_update_payload(
-    bug: dict, repo_name: str, milestone: int
+    bug: dict, repo_name: str, milestone: int, milestone_tracking_flag_template: str
 ) -> dict[str, Any]:
     """Create a payload for updating a bug using the BMO REST API.
 
@@ -321,9 +321,12 @@ def create_uplift_bug_update_payload(
         "ids": [int(bug["id"])],
     }
 
-    milestone_tracking_flag = f"cf_status_firefox{milestone}"
+    milestone_tracking_flag = milestone_tracking_flag_template.format(
+        milestone=milestone
+    )
     if (
-        "keywords" in bug
+        milestone_tracking_flag
+        and "keywords" in bug
         and "leave-open" not in bug["keywords"]
         and milestone_tracking_flag in bug
     ):
@@ -342,6 +345,7 @@ def create_uplift_bug_update_payload(
 def update_bugs_for_uplift(
     repo_name: str,
     milestone_file_contents: str,
+    milestone_tracking_flag_template: str,
     bug_ids: list[str],
 ):
     """Update Bugzilla bugs for uplift."""
@@ -360,7 +364,9 @@ def update_bugs_for_uplift(
 
     # Create bug update payloads.
     payloads = [
-        create_uplift_bug_update_payload(bug, repo_name, milestone.major)
+        create_uplift_bug_update_payload(
+            bug, repo_name, milestone.major, milestone_tracking_flag_template
+        )
         for bug in bugs
     ]
 

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -454,6 +454,7 @@ class LandingWorker(Worker):
                 update_bugs_for_uplift(
                     repo.short_name,
                     hgrepo.read_checkout_file("config/milestone.txt"),
+                    repo.milestone_tracking_flag_template,
                     bug_ids,
                 )
             except Exception as e:

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -298,7 +298,9 @@ def test_create_uplift_bug_update_payload():
         "keywords": [],
         "whiteboard": "[checkin-needed-beta]",
     }
-    payload = create_uplift_bug_update_payload(bug, "beta", 100)
+    payload = create_uplift_bug_update_payload(
+        bug, "beta", 100, "cf_status_firefox{milestone}"
+    )
 
     assert payload["ids"] == [123], "Passed bug ID should be present in the payload."
     assert (
@@ -314,7 +316,9 @@ def test_create_uplift_bug_update_payload():
         "keywords": ["leave-open"],
         "whiteboard": "[checkin-needed-beta]",
     }
-    payload = create_uplift_bug_update_payload(bug, "beta", 100)
+    payload = create_uplift_bug_update_payload(
+        bug, "beta", 100, "cf_status_firefox{milestone}"
+    )
 
     assert (
         "cf_status_firefox100" not in payload


### PR DESCRIPTION
The status tracking flags for ESR differ slightly from beta and release.
Make the tracking flag configurable per-repo instead of hard-coded to
a specific format. On the Bugzilla side the uplift API endpoint allows
changing any `cf_status_*` flag.
