### PR TITLE
auth: make `scopes` a required argument in `require_auth0` decorator (Bug 1832362)

### DIFF
--- a/landoapi/auth.py
+++ b/landoapi/auth.py
@@ -356,11 +356,7 @@ class require_auth0:
     accessed using flask.g.auth0_user.
     """
 
-    def __init__(self, scopes: Optional[Iterable[str]] = None, userinfo: bool = False):
-        assert scopes is not None, (
-            "`scopes` must be provided. If this endpoint truly does not "
-            "require any scopes, explicilty pass an empty tuple `()`"
-        )
+    def __init__(self, scopes: Iterable[str], userinfo: bool = False):
         self.userinfo = userinfo
         self.scopes = scopes
 


### PR DESCRIPTION
Change `scopes` from a keyword argument to a positional argument,
indicating that scopes must be passed to the decorator. The keyword
argument syntax of `scopes=` still works for positional arguments
so no other changes are required and the purpose of the argument
is still clear when reading usages of the decorator.
