### PR TITLE
typing: add types to `hgexports.py` and fix `set_patch` types (Bug 1759890)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -1,6 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import annotations
+
+import io
 import re
 from typing import (
     Optional,
@@ -34,16 +38,16 @@ _HG_EXPORT_HEADER_LENGTH = len(_HG_EXPORT_HEADER.splitlines())
 
 
 def build_patch_for_revision(
-    diff, author_name, author_email, commit_message, timestamp
-):
+    diff: str, author_name: str, author_email: str, commit_message: str, timestamp: str
+) -> str:
     """Generate a 'hg export' patch using Phabricator Revision data.
 
     Args:
         diff: A string holding a Git-formatted patch.
         author: A string with information about the patch's author.
         commit_message: A string containing the full commit message.
-        timestamp: (int) Number of seconds since Unix Epoch representing the date and
-            time to be included in the Date header.
+        timestamp: (str) String number of seconds since Unix Epoch representing the
+            date and time to be included in the Date header.
 
     Returns:
         A string containing a patch in 'hg export' format.
@@ -62,15 +66,15 @@ def build_patch_for_revision(
     )
 
 
-def _no_line_breaks(s):
-    """Return s with all line breaks removed."""
-    return "".join(s.strip().splitlines())
+def _no_line_breaks(break_string: str) -> str:
+    """Return `break_string` with all line breaks removed."""
+    return "".join(break_string.strip().splitlines())
 
 
 class PatchHelper(object):
     """Helper class for parsing Mercurial patches/exports."""
 
-    def __init__(self, fileobj):
+    def __init__(self, fileobj: io.BytesIO):
         self.patch = fileobj
         self.headers = {}
         self.header_end_line_no = 0
@@ -87,11 +91,11 @@ class PatchHelper(object):
                 self.diff_start_line = None
 
     @staticmethod
-    def _is_diff_line(line):
-        return DIFF_LINE_RE.search(line)
+    def _is_diff_line(line: bytes) -> bool:
+        return DIFF_LINE_RE.search(line) is not None
 
     @staticmethod
-    def _header_value(line, prefix):
+    def _header_value(line: bytes, prefix: bytes) -> Optional[bytes]:
         m = re.search(
             rb"^#\s+" + re.escape(prefix) + rb"\s+(.*)", line, flags=re.IGNORECASE
         )
@@ -115,12 +119,12 @@ class PatchHelper(object):
         finally:
             self.patch.seek(0)
 
-    def header(self, name) -> Optional[str]:
+    def header(self, name: bytes | str) -> Optional[bytes]:
         """Returns value of the specified header, or None if missing."""
         name = name.encode("utf-8") if isinstance(name, str) else name
         return self.headers.get(name.lower())
 
-    def commit_description(self):
+    def commit_description(self) -> bytes:
         """Returns the commit description."""
         try:
             line_no = 0
@@ -144,7 +148,7 @@ class PatchHelper(object):
         finally:
             self.patch.seek(0)
 
-    def write(self, f):
+    def write(self, f: io.BytesIO):
         """Writes whole patch to the specified file object."""
         try:
             while 1:
@@ -155,11 +159,11 @@ class PatchHelper(object):
         finally:
             self.patch.seek(0)
 
-    def write_commit_description(self, f):
+    def write_commit_description(self, f: io.BytesIO):
         """Writes the commit description to the specified file object."""
         f.write(self.commit_description())
 
-    def write_diff(self, f):
+    def write_diff(self, f: io.BytesIO):
         """Writes the diff to the specified file object."""
         try:
             line_no = 0

--- a/landoapi/models/revisions.py
+++ b/landoapi/models/revisions.py
@@ -81,7 +81,7 @@ class Revision(Base):
         """Return a Revision object from a given ID."""
         return cls.query.filter(Revision.revision_id == revision_id).one_or_none()
 
-    def set_patch(self, raw_diff: bytes, patch_data: dict[str, str]):
+    def set_patch(self, raw_diff: str, patch_data: dict[str, str]):
         """Given a raw_diff and patch data, build the patch and store it."""
         self.patch_data = patch_data
         patch = build_patch_for_revision(raw_diff, **self.patch_data)


### PR DESCRIPTION
While testing the try API endpoint I noticed my very simple
patch was failing to apply. This is because the type hint for
`Revision.set_patch` is incorrect and the raw diff returned
from Phabricator is actually a `str`, not `bytes`, and thus the
type I was using was incorrect. The timestamp is also a `str`
and not an `int`. Update the function signature to match reality,
and while we're here add type hints to all of `hgexports.py`.
