### PR TITLE
hg: retry after Mercurial repo lock waiting timeouts (Bug 1853965)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -43,7 +43,13 @@ class HgException(Exception):
             err.decode(errors="replace"),
         ).rstrip()
 
-        for cls in (LostPushRace, PatchConflict, TreeClosed, TreeApprovalRequired):
+        for cls in (
+            LostPushRace,
+            PatchConflict,
+            TreeClosed,
+            TreeApprovalRequired,
+            TryPushTimeoutException,
+        ):
             for s in cls.SNIPPETS:
                 if s in err or s in out:
                     return cls(msg)
@@ -78,6 +84,12 @@ class LostPushRace(HgException):
         b"abort: push creates new remote head",
         b"repository changed while pushing",
     )
+
+
+class TryPushTimeoutException(HgException):
+    """Exception when pushing failed due to a timeout on the Try repo."""
+
+    SNIPPETS = (b"abort: working directory of /repo/hg/mozilla/try: timed out waiting",)
 
 
 class PatchApplicationFailure(HgException):

--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -48,7 +48,7 @@ class HgException(Exception):
             PatchConflict,
             TreeClosed,
             TreeApprovalRequired,
-            TryPushTimeoutException,
+            PushTimeoutException,
         ):
             for s in cls.SNIPPETS:
                 if s in err or s in out:
@@ -86,10 +86,10 @@ class LostPushRace(HgException):
     )
 
 
-class TryPushTimeoutException(HgException):
+class PushTimeoutException(HgException):
     """Exception when pushing failed due to a timeout on the Try repo."""
 
-    SNIPPETS = (b"abort: working directory of /repo/hg/mozilla/try: timed out waiting",)
+    SNIPPETS = (b"timed out waiting for lock held by",)
 
 
 class PatchApplicationFailure(HgException):

--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -87,7 +87,7 @@ class LostPushRace(HgException):
 
 
 class PushTimeoutException(HgException):
-    """Exception when pushing failed due to a timeout on the Try repo."""
+    """Exception when pushing failed due to a timeout on the repo."""
 
     SNIPPETS = (b"timed out waiting for lock held by",)
 

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -21,9 +21,9 @@ from landoapi.hg import (
     LostPushRace,
     NoDiffStartLine,
     PatchConflict,
+    PushTimeoutException,
     TreeApprovalRequired,
     TreeClosed,
-    TryPushTimeoutException,
 )
 from landoapi.models.configuration import ConfigurationKey
 from landoapi.models.landing_job import LandingJob, LandingJobAction, LandingJobStatus
@@ -396,7 +396,7 @@ class LandingWorker(Worker):
                 TreeClosed,
                 TreeApprovalRequired,
                 LostPushRace,
-                TryPushTimeoutException,
+                PushTimeoutException,
             ) as e:
                 message = (
                     f"`Temporary error ({e.__class__}) "

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -23,6 +23,7 @@ from landoapi.hg import (
     PatchConflict,
     TreeApprovalRequired,
     TreeClosed,
+    TryPushTimeoutException,
 )
 from landoapi.models.configuration import ConfigurationKey
 from landoapi.models.landing_job import LandingJob, LandingJobAction, LandingJobStatus
@@ -391,7 +392,12 @@ class LandingWorker(Worker):
                     bookmark=repo.push_bookmark or None,
                     force_push=repo.force_push,
                 )
-            except (TreeClosed, TreeApprovalRequired, LostPushRace) as e:
+            except (
+                TreeClosed,
+                TreeApprovalRequired,
+                LostPushRace,
+                TryPushTimeoutException,
+            ) as e:
                 message = (
                     f"`Temporary error ({e.__class__}) "
                     f"encountered while pushing to {repo_info}"

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -14,9 +14,9 @@ from landoapi.hg import (
     LostPushRace,
     NoDiffStartLine,
     PatchConflict,
+    PushTimeoutException,
     TreeApprovalRequired,
     TreeClosed,
-    TryPushTimeoutException,
     hglib,
 )
 
@@ -234,7 +234,7 @@ def test_hg_exceptions():
         b"APPROVAL REQUIRED!": TreeApprovalRequired,
         b"is CLOSED!": TreeClosed,
         b"unresolved conflicts (see hg resolve": PatchConflict,
-        b"abort: working directory of /repo/hg/mozilla/try: timed out waiting for lock": TryPushTimeoutException,
+        b"timed out waiting for lock held by": PushTimeoutException,
     }
 
     for snippet, exception in snippet_exception_mapping.items():

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -16,6 +16,7 @@ from landoapi.hg import (
     PatchConflict,
     TreeApprovalRequired,
     TreeClosed,
+    TryPushTimeoutException,
     hglib,
 )
 
@@ -233,6 +234,7 @@ def test_hg_exceptions():
         b"APPROVAL REQUIRED!": TreeApprovalRequired,
         b"is CLOSED!": TreeClosed,
         b"unresolved conflicts (see hg resolve": PatchConflict,
+        b"abort: working directory of /repo/hg/mozilla/try: timed out waiting for lock": TryPushTimeoutException,
     }
 
     for snippet, exception in snippet_exception_mapping.items():


### PR DESCRIPTION
When pushes fail due to timeouts waiting for the repo lock,
Lando should wait and retry the push. Add a new exception for
this condition that includes snippets of the expected output
from Mercurial, and add the exception to the block of temporary
failure exceptions when trying to push.
