### PR TITLE
landing_jobs: raise a `ProblemException` for improper date format (Bug 1855566)

### DIFF
--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -74,6 +74,22 @@ def put(landing_job_id: str, data: dict):
         )
 
 
+def try_convert_datetime(date: str) -> datetime:
+    """Attempt to convert a `str` version of a date to a `datetime`.
+
+    Raise a `ProblemException` on error.
+    """
+    try:
+        return datetime.fromisoformat(date)
+    except ValueError:
+        raise ProblemException(
+            400,
+            f"Passed date value {date} is not a valid date.",
+            f"Passed date value {date} is not a valid date.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
+        )
+
+
 def get_stats(start_date: str = "", end_date: str = "") -> dict:
     """Return landing job statistics between given dates.
 
@@ -87,12 +103,12 @@ def get_stats(start_date: str = "", end_date: str = "") -> dict:
     if not start_date:
         start_date_datetime = datetime.now()
     else:
-        start_date_datetime = datetime.fromisoformat(start_date)
+        start_date_datetime = try_convert_datetime(start_date)
 
     if not end_date:
         end_date_datetime = datetime.now()
     else:
-        end_date_datetime = datetime.fromisoformat(end_date)
+        end_date_datetime = try_convert_datetime(end_date)
 
     start_date_datetime = start_date_datetime.replace(
         hour=0, minute=0, second=0, microsecond=0

--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -74,7 +74,7 @@ def put(landing_job_id: str, data: dict):
         )
 
 
-def try_convert_datetime(date: str) -> datetime:
+def datetime_from_string(date: str) -> datetime:
     """Attempt to convert a `str` version of a date to a `datetime`.
 
     Raise a `ProblemException` on error.

--- a/tests/test_landing_job.py
+++ b/tests/test_landing_job.py
@@ -158,3 +158,11 @@ def test_landing_job_acquire_job_job_queue_query(db):
     assert queue_items[0] is jobs[2]
     assert queue_items[1] is jobs[0]
     assert jobs[1] not in queue_items
+
+
+def test_stats_validate_date(db, client, landing_job):
+    landing_job(LandingJobStatus.SUBMITTED)
+
+    response = client.get("/stats?end_date=@@B41w8&start_date=test")
+
+    assert response.status_code == 400


### PR DESCRIPTION
Verify the value passed in the query string is indeed a datetime
object.
