### PR TITLE
landings: use `StringIO` instead of `BytesIO` everywhere (Bug 1855328)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import configparser
 import copy
+import io
 import logging
 import os
 import shlex
@@ -313,7 +314,7 @@ class HgRepo:
             except hglib.error.CommandError:
                 pass
 
-    def apply_patch(self, patch_io_buf):
+    def apply_patch(self, patch_io_buf: io.StringIO):
         patch_helper = HgPatchHelper(patch_io_buf)
         if not patch_helper.diff_start_line:
             raise NoDiffStartLine()
@@ -322,8 +323,8 @@ class HgRepo:
 
         # Import the diff to apply the changes then commit separately to
         # ensure correct parsing of the commit message.
-        f_msg = tempfile.NamedTemporaryFile()
-        f_diff = tempfile.NamedTemporaryFile()
+        f_msg = tempfile.NamedTemporaryFile(encoding="utf-8", mode="w+")
+        f_diff = tempfile.NamedTemporaryFile(encoding="utf-8", mode="w+")
         with f_msg, f_diff:
             patch_helper.write_commit_description(f_msg)
             f_msg.flush()

--- a/landoapi/models/revisions.py
+++ b/landoapi/models/revisions.py
@@ -82,6 +82,11 @@ class Revision(Base):
         )
         return f"<{self.__class__.__name__}: {self.id}{phab_identifier}>"
 
+    @property
+    def patch_string(self) -> str:
+        """Return the patch as a UTF-8 encoded string."""
+        return self.patch_bytes.decode("utf-8")
+
     @classmethod
     def get_from_revision_id(cls, revision_id: int) -> "Revision" | None:
         """Return a Revision object from a given ID."""

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -7,7 +7,7 @@ import logging
 import re
 from contextlib import contextmanager
 from datetime import datetime
-from io import BytesIO
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -295,7 +295,7 @@ class LandingWorker(Worker):
 
             # Run through the patches one by one and try to apply them.
             for revision in job.revisions:
-                patch_buf = BytesIO(revision.patch_bytes)
+                patch_buf = StringIO(revision.patch_string)
 
                 try:
                     hgrepo.apply_patch(patch_buf)

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -78,7 +78,7 @@ def test_integrated_hgrepo_can_log(hg_clone):
         assert repo.run_hg_cmds([["log"]])
 
 
-PATCH_WITHOUT_STARTLINE = rb"""
+PATCH_WITHOUT_STARTLINE = r"""
 # HG changeset patch
 # User Test User <test@example.com>
 # Date 0 0
@@ -93,7 +93,7 @@ diff --git a/test.txt b/test.txt
 """.strip()
 
 
-PATCH_WITH_CONFLICT = rb"""
+PATCH_WITH_CONFLICT = r"""
 # HG changeset patch
 # User Test User <test@example.com>
 # Date 0 0
@@ -109,7 +109,7 @@ diff --git a/not-real.txt b/not-real.txt
 """.strip()
 
 
-PATCH_DELETE_NO_NEWLINE_FILE = b"""
+PATCH_DELETE_NO_NEWLINE_FILE = """
 # HG changeset patch
 # User Test User <test@example.com>
 # Date 0 0
@@ -126,7 +126,7 @@ deleted file mode 100644
 \\ No newline at end of file
 """.strip()
 
-PATCH_NORMAL = rb"""
+PATCH_NORMAL = r"""
 # HG changeset patch
 # User Test User <test@example.com>
 # Date 0 0
@@ -154,11 +154,10 @@ diff --git a/test.txt b/test.txt
 @@ -1,1 +1,2 @@
  TEST
 +adding another line
-""".strip().encode(
-    "utf-8"
-)
+""".strip()
 
-PATCH_FAIL_HEADER = b"""
+
+PATCH_FAIL_HEADER = """
 # HG changeset patch
 # User Test User <test@example.com>
 # Date 0 0
@@ -181,19 +180,19 @@ def test_integrated_hgrepo_apply_patch(hg_clone):
     # We should refuse to apply patches that are missing a
     # Diff Start Line header.
     with pytest.raises(NoDiffStartLine), repo.for_pull():
-        repo.apply_patch(io.BytesIO(PATCH_WITHOUT_STARTLINE))
+        repo.apply_patch(io.StringIO(PATCH_WITHOUT_STARTLINE))
 
     # Patches with conflicts should raise a proper PatchConflict exception.
     with pytest.raises(PatchConflict), repo.for_pull():
-        repo.apply_patch(io.BytesIO(PATCH_WITH_CONFLICT))
+        repo.apply_patch(io.StringIO(PATCH_WITH_CONFLICT))
 
     with repo.for_pull():
-        repo.apply_patch(io.BytesIO(PATCH_NORMAL))
+        repo.apply_patch(io.StringIO(PATCH_NORMAL))
         # Commit created.
         assert repo.run_hg(["outgoing"])
 
     with repo.for_pull():
-        repo.apply_patch(io.BytesIO(PATCH_UNICODE))
+        repo.apply_patch(io.StringIO(PATCH_UNICODE))
         # Commit created.
 
         log_output = repo.run_hg(["log"])
@@ -201,7 +200,7 @@ def test_integrated_hgrepo_apply_patch(hg_clone):
         assert repo.run_hg(["outgoing"])
 
     with repo.for_pull():
-        repo.apply_patch(io.BytesIO(PATCH_FAIL_HEADER))
+        repo.apply_patch(io.StringIO(PATCH_FAIL_HEADER))
         # Commit created.
         assert repo.run_hg(["outgoing"])
 
@@ -222,7 +221,7 @@ def test_integrated_hgrepo_apply_patch_newline_bug(hg_clone):
         repo.run_hg_cmds(
             [["add", new_file.strpath], ["commit", "-m", "adding file"], ["push"]]
         )
-        repo.apply_patch(io.BytesIO(PATCH_DELETE_NO_NEWLINE_FILE))
+        repo.apply_patch(io.StringIO(PATCH_DELETE_NO_NEWLINE_FILE))
         # Commit created.
         assert "file removed" in str(repo.run_hg(["outgoing"]))
 

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -57,7 +57,7 @@ diff --git a/hello.c b/hello.c
  }
 """
 
-GIT_PATCH = rb"""
+GIT_PATCH = r"""
 From 0f5a3c99e12c1e9b0e81bed245fe537961f89e57 Mon Sep 17 00:00:00 2001
 From: Connor Sheehan <sheehan@mozilla.com>
 Date: Wed, 6 Jul 2022 16:36:09 -0400
@@ -153,8 +153,8 @@ def test_patchhelper_is_diff_line(line, expected):
 
 def test_patchhelper_vanilla_export():
     patch = HgPatchHelper(
-        io.BytesIO(
-            b"""
+        io.StringIO(
+            """
 # HG changeset patch
 # User byron jones <glob@mozilla.com>
 # Date 1523427125 -28800
@@ -181,8 +181,8 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 
 def test_patchhelper_start_line():
     patch = HgPatchHelper(
-        io.BytesIO(
-            b"""
+        io.StringIO(
+            """
 # HG changeset patch
 # User byron jones <glob@mozilla.com>
 # Date 1523427125 -28800
@@ -207,8 +207,8 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 
 def test_patchhelper_no_header():
     patch = HgPatchHelper(
-        io.BytesIO(
-            b"""
+        io.StringIO(
+            """
 WIP transplant and diff-start-line
 
 diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
@@ -226,8 +226,8 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 
 def test_patchhelper_diff_injection_no_start_line():
     patch = HgPatchHelper(
-        io.BytesIO(
-            b"""
+        io.StringIO(
+            """
 # HG changeset patch
 # User byron jones <glob@mozilla.com>
 # Date 1523427125 -28800
@@ -254,8 +254,8 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 
 def test_patchhelper_diff_injection_start_line():
     patch = HgPatchHelper(
-        io.BytesIO(
-            b"""
+        io.StringIO(
+            """
 # HG changeset patch
 # User byron jones <glob@mozilla.com>
 # Date 1523427125 -28800
@@ -288,7 +288,7 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 
 
 def test_patchhelper_write_start_line():
-    header = b"""
+    header = """
 # HG changeset patch
 # User byron jones <glob@mozilla.com>
 # Date 1523427125 -28800
@@ -297,10 +297,10 @@ def test_patchhelper_write_start_line():
 # Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
 # Diff Start Line 10
 """.strip()
-    commit_desc = b"""
+    commit_desc = """
 WIP transplant and diff-start-line
 """.strip()
-    diff = b"""
+    diff = """
 diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 --- a/autoland/autoland/transplant.py
 +++ b/autoland/autoland/transplant.py
@@ -308,13 +308,13 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 # instead of passing the url to 'hg import' to make
 ...
 """.strip()
-    patch = HgPatchHelper(io.BytesIO(b"%s\n%s\n\n%s" % (header, commit_desc, diff)))
+    patch = HgPatchHelper(io.StringIO("%s\n%s\n\n%s" % (header, commit_desc, diff)))
 
-    buf = io.BytesIO(b"")
+    buf = io.StringIO("")
     patch.write_commit_description(buf)
     assert buf.getvalue() == commit_desc
 
-    buf = io.BytesIO(b"")
+    buf = io.StringIO("")
     patch.write_diff(buf)
     assert buf.getvalue() == diff
 
@@ -339,23 +339,21 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 # instead of passing the url to 'hg import' to make
 ...
 """.strip()
-    patch = HgPatchHelper(
-        io.BytesIO(f"{header}\n{commit_desc}\n\n{diff}".encode("utf-8"))
-    )
+    patch = HgPatchHelper(io.StringIO(f"{header}\n{commit_desc}\n\n{diff}"))
 
-    buf = io.BytesIO(b"")
+    buf = io.StringIO("")
     patch.write_commit_description(buf)
-    assert buf.getvalue().decode("utf-8") == commit_desc
+    assert buf.getvalue() == commit_desc
 
     assert patch.get_diff() == diff
 
-    buf = io.BytesIO(b"")
+    buf = io.StringIO("")
     patch.write_diff(buf)
-    assert buf.getvalue().decode("utf-8") == diff
+    assert buf.getvalue() == diff
 
 
 def test_git_formatpatch_helper_parse():
-    patch = GitPatchHelper(io.BytesIO(GIT_PATCH))
+    patch = GitPatchHelper(io.StringIO(GIT_PATCH))
     assert (
         patch.get_header("From") == "Connor Sheehan <sheehan@mozilla.com>"
     ), "`From` header should contain author information."

--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -589,7 +589,7 @@ def test_format_single_success_changed(
     # Push the `mach` formatting patch.
     hgrepo = HgRepo(hg_clone.strpath)
     with hgrepo.for_push("test@example.com"):
-        hgrepo.apply_patch(io.BytesIO(PATCH_FORMATTING_PATTERN_PASS.encode("utf-8")))
+        hgrepo.apply_patch(io.StringIO(PATCH_FORMATTING_PATTERN_PASS))
         hgrepo.push(repo.push_path)
         pre_landing_tip = hgrepo.run_hg(["log", "-r", "tip", "-T", "{node}"]).decode(
             "utf-8"

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1188,10 +1188,9 @@ def test_integrated_transplant_sec_approval_group_is_excluded_from_reviewers_lis
     assert response == 202
 
     # Check the transplanted patch for our alternate commit message.
-    patch_text = Revision.get_from_revision_id(revision["id"]).patch_bytes.decode(
-        "utf-8"
-    )
-    assert sec_approval_project["name"] not in patch_text
+    transplanted_patch = Revision.get_from_revision_id(revision["id"])
+    assert transplanted_patch is not None, "Transplanted patch should be retrievable."
+    assert sec_approval_project["name"] not in transplanted_patch.patch_string
 
 
 def test_warning_wip_commit_message(phabdouble):


### PR DESCRIPTION
Transition from using `io.BytesIO` to `io.StringIO` for content buffers.
Update uses of `NamedTemporaryFile` to open in `w+` mode with a specified
encoding.