### PR TITLE
hg: add a `PullFailureException` to retry landings after a 500 during pull (Bug 1858500)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -50,6 +50,7 @@ class HgException(Exception):
             TreeClosed,
             TreeApprovalRequired,
             PushTimeoutException,
+            PullFailureException,
         ):
             for s in cls.SNIPPETS:
                 if s in err or s in out:
@@ -91,6 +92,12 @@ class PushTimeoutException(HgException):
     """Exception when pushing failed due to a timeout on the repo."""
 
     SNIPPETS = (b"timed out waiting for lock held by",)
+
+
+class PullFailureException(HgException):
+    """Exception when pulling changes from the upstream repo fails."""
+
+    SNIPPETS = (b"Unexpected error while fetching repo",)
 
 
 class PatchApplicationFailure(HgException):

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -280,7 +280,7 @@ class LandingWorker(Worker):
 
         with hgrepo.for_push(job.requester_email):
             # Update local repo.
-            repo_pull_info = f"tree: {repo.tree}, push path: {repo.push_path}"
+            repo_pull_info = f"tree: {repo.tree}, pull path: {repo.pull_path}"
             try:
                 hgrepo.update_repo(repo.pull_path, target_cset=job.target_commit_hash)
             except PullFailureException as e:

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -14,6 +14,7 @@ from landoapi.hg import (
     LostPushRace,
     NoDiffStartLine,
     PatchConflict,
+    PullFailureException,
     PushTimeoutException,
     TreeApprovalRequired,
     TreeClosed,
@@ -234,6 +235,7 @@ def test_hg_exceptions():
         b"is CLOSED!": TreeClosed,
         b"unresolved conflicts (see hg resolve": PatchConflict,
         b"timed out waiting for lock held by": PushTimeoutException,
+        b"Unexpected error while fetching repo from localhost": PullFailureException,
     }
 
     for snippet, exception in snippet_exception_mapping.items():


### PR DESCRIPTION
Add a `PullFailureException` with a snippet that looks for errors
during `hg pull` and add it to the list of Lando exceptions
that can be raised from an hglib exception. Add an except
case to the `update_repo` try block that is similar to the case
in the `push` try block, to allow the job to be retried when this
exception is encountered.
