### PR TITLE
hg: change `PullFailureException` to `HgmoInternalServerError` (Bug 1860067)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -50,7 +50,7 @@ class HgException(Exception):
             TreeClosed,
             TreeApprovalRequired,
             PushTimeoutException,
-            PullFailureException,
+            HgmoInternalServerError,
         ):
             for s in cls.SNIPPETS:
                 if s in err or s in out:
@@ -94,10 +94,10 @@ class PushTimeoutException(HgException):
     SNIPPETS = (b"timed out waiting for lock held by",)
 
 
-class PullFailureException(HgException):
+class HgmoInternalServerError(HgException):
     """Exception when pulling changes from the upstream repo fails."""
 
-    SNIPPETS = (b"Unexpected error while fetching repo",)
+    SNIPPETS = (b"abort: HTTP Error 500:",)
 
 
 class PatchApplicationFailure(HgException):

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -17,11 +17,11 @@ from landoapi.commit_message import parse_bugs
 from landoapi.hg import (
     REJECTS_PATH,
     AutoformattingException,
+    HgmoInternalServerError,
     HgRepo,
     LostPushRace,
     NoDiffStartLine,
     PatchConflict,
-    PullFailureException,
     PushTimeoutException,
     TreeApprovalRequired,
     TreeClosed,
@@ -283,7 +283,7 @@ class LandingWorker(Worker):
             repo_pull_info = f"tree: {repo.tree}, pull path: {repo.pull_path}"
             try:
                 hgrepo.update_repo(repo.pull_path, target_cset=job.target_commit_hash)
-            except PullFailureException as e:
+            except HgmoInternalServerError as e:
                 message = (
                     f"`Temporary error ({e.__class__}) "
                     f"encountered while pulling from {repo_pull_info}"
@@ -410,6 +410,7 @@ class LandingWorker(Worker):
                 TreeApprovalRequired,
                 LostPushRace,
                 PushTimeoutException,
+                HgmoInternalServerError,
             ) as e:
                 message = (
                     f"`Temporary error ({e.__class__}) "

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -10,11 +10,11 @@ from landoapi.hg import (
     REQUEST_USER_ENV_VAR,
     HgCommandError,
     HgException,
+    HgmoInternalServerError,
     HgRepo,
     LostPushRace,
     NoDiffStartLine,
     PatchConflict,
-    PullFailureException,
     PushTimeoutException,
     TreeApprovalRequired,
     TreeClosed,
@@ -235,7 +235,7 @@ def test_hg_exceptions():
         b"is CLOSED!": TreeClosed,
         b"unresolved conflicts (see hg resolve": PatchConflict,
         b"timed out waiting for lock held by": PushTimeoutException,
-        b"Unexpected error while fetching repo from localhost": PullFailureException,
+        b"abort: HTTP Error 500: Internal Server Error": HgmoInternalServerError,
     }
 
     for snippet, exception in snippet_exception_mapping.items():


### PR DESCRIPTION
The error snippet for `PullFailureException` is a piece of text that
comes from Lando, not Mercurial. The correct piece of text to look
for is `abort: HTTP Error 500`, which is a more general error that
can happen when load on hg is high.

Rename `PullFailureException` to `HgmoInternalServerError` and update
the snippet to reflect the output from hg. Since this error is more
general, we also add it to the set of exceptions to consider a temporary
failure at push time.
