### PR TITLE
docker: add `--upgrade` to `pip-compile` command (Bug 1824007)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         target: python_base
     volumes:
       - ./:/app
-    command: sh -c "cd /app && pip install pip --upgrade && pip install pip-tools && python -m piptools compile requirements.in --generate-hashes --allow-unsafe"
+    command: sh -c "cd /app && pip install pip --upgrade && pip install pip-tools && python -m piptools compile requirements.in --generate-hashes --allow-unsafe --upgrade"
   lando-api:
     build:
       context: ./


### PR DESCRIPTION
Add `--upgrade` to the `pip-compile` command in our `build-requirements`
docker-compose recipe so packages are upgraded to later versions when possible.
