### PR TITLE
emails: make landing failure emails less Phab-specific (Bug 1855851)

### DIFF
--- a/landoapi/email.py
+++ b/landoapi/email.py
@@ -4,12 +4,14 @@
 import logging
 from email.message import EmailMessage
 
+from landoapi.validation import REVISION_ID_RE
+
 logger = logging.getLogger(__name__)
 
 LANDING_FAILURE_EMAIL_TEMPLATE = """
 Your request to land {landing_job_identifier} failed.
 
-See {lando_revision_url} for details.
+See {error_details_location} for details.
 
 Reason:
 {reason}
@@ -35,11 +37,20 @@ def make_failure_email(
     msg["From"] = from_email
     msg["To"] = recipient_email
     msg["Subject"] = f"Lando: Landing of {landing_job_identifier} failed!"
-    lando_revision_url = f"{lando_ui_url}/{landing_job_identifier}/"
+
+    if REVISION_ID_RE.match(landing_job_identifier):
+        # If the landing job identifier looks like a Phab revision,
+        # link to the relevant view page.
+        error_details_location = f"{lando_ui_url}/{landing_job_identifier}/"
+    else:
+        # If there is no relevant URL to show the user in the email, the error
+        # details in the bottom of the email is all we have to show them for now.
+        error_details_location = "below"
+
     msg.set_content(
         LANDING_FAILURE_EMAIL_TEMPLATE.format(
             landing_job_identifier=landing_job_identifier,
-            lando_revision_url=lando_revision_url,
+            error_details_location=error_details_location,
             reason=error_msg,
         )
     )

--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -181,7 +181,7 @@ class LandingJob(Base):
         """
         if not self.revisions:
             raise ValueError(
-                "Job must be associated with a revision to have a head revision."
+                "Job must be associated with a revision to have a relevant identifier."
             )
 
         head = self.revisions[-1]
@@ -196,7 +196,7 @@ class LandingJob(Base):
 
         commit_message = head.patch_data.get("commit_message")
         if commit_message:
-            return commit_message.splitlines()[0]
+            return f"try push with tip commit '{commit_message.splitlines()[0]}'"
 
         # Return a placeholder in the event neither exists.
         return "unknown"

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -64,7 +64,7 @@ def test_send_failure_notification_email_task(app, smtp):
     assert len(smtp.outbox) == 1
 
 
-def test_email_content():
+def test_email_content_phabricator():
     email = make_failure_email(
         "mozphab-prod@mozilla.com",
         "sadpanda@failure.test",
@@ -77,6 +77,28 @@ def test_email_content():
     expected_body = (
         "Your request to land D54321 failed.\n\n"
         "See https://lando.test/D54321/ for details.\n\n"
+        "Reason:\n"
+        "Rebase failed!"
+    )
+    assert email.get_content() == expected_body + "\n"
+
+
+def test_email_content_try():
+    email = make_failure_email(
+        "mozphab-prod@mozilla.com",
+        "sadpanda@failure.test",
+        "try push with tip commit 'testing 123'",
+        "Rebase failed!",
+        "https://lando.test",
+    )
+    assert email["To"] == "sadpanda@failure.test"
+    assert (
+        email["Subject"]
+        == "Lando: Landing of try push with tip commit 'testing 123' failed!"
+    )
+    expected_body = (
+        "Your request to land try push with tip commit 'testing 123' failed.\n\n"
+        "See below for details.\n\n"
         "Reason:\n"
         "Rebase failed!"
     )


### PR DESCRIPTION
Make the Phabricator landing emails less Phabricator-specific.
Update the landing job identifier to include the context that
the job belongs to a try push with the included commit message
title. Add a check of the landing job identifier to only display
a link to a Lando-UI URL when the identifier is a Phab revision
ID.
