### PR TITLE
landing-job: add a type hint to `revisions` (Bug 1759890)

### DIFF
--- a/landoapi/models/landing_job.py
+++ b/landoapi/models/landing_job.py
@@ -132,7 +132,7 @@ class LandingJob(Base):
     # Identifier of the published commit which this job should land on top of.
     target_commit_hash = db.Column(db.Text(), nullable=True)
 
-    revisions = db.relationship(
+    revisions: list[Revision] = db.relationship(
         "Revision",
         secondary=revision_landing_job,
         back_populates="landing_jobs",


### PR DESCRIPTION
Add a type hint for `LandingJob.revisions`. This fixes LSP features on this field,
which don't work at the moment as the LSP can't infer the type from SQLAlchemy's
string-based type hints.
