### PR TITLE
hgexports: empty Git commits aren't parsed correctly (Bug 1867036)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -319,6 +319,13 @@ class GitPatchHelper(PatchHelper):
                 commit_message_lines += [""]
 
             commit_message_lines.append(line)
+        else:
+            # We never found the end of the commit message body, so this change
+            # must be an empty commit. Discard the last two lines of the
+            # constructed commit message which are Git version info and return
+            # an empty diff.
+            commit_message = "\n".join(commit_message_lines[:-2])
+            return commit_message, ""
 
         commit_message = "\n".join(commit_message_lines)
 

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -122,6 +122,21 @@ index f56ba1c..33391ea 100644
          500,
 """.rstrip()
 
+GIT_PATCH_EMPTY = """
+From 0f5a3c99e12c1e9b0e81bed245fe537961f89e57 Mon Sep 17 00:00:00 2001
+From: Connor Sheehan <sheehan@mozilla.com>
+Date: Wed, 6 Jul 2022 16:36:09 -0400
+Subject: [PATCH] errors: add a maintenance-mode specific title to serverside
+ error handlers (Bug 1724769)
+
+Adds a conditional to the Lando-API exception handlers that
+shows a maintenance-mode specific title when a 503 error is
+returned from Lando. This should inform users that Lando is
+unavailable at the moment and is not broken.
+--
+2.31.1
+""".strip()
+
 
 def test_build_patch():
     patch = build_patch_for_revision(
@@ -375,3 +390,26 @@ def test_git_formatpatch_helper_parse():
     assert (
         patch.get_diff() == GIT_PATCH_ONLY_DIFF
     ), "`get_diff()` should return the full diff."
+
+
+def test_git_formatpatch_helper_empty_commit():
+    patch = GitPatchHelper(io.StringIO(GIT_PATCH_EMPTY))
+    assert (
+        patch.get_header("From") == "Connor Sheehan <sheehan@mozilla.com>"
+    ), "`From` header should contain author information."
+    assert (
+        patch.get_header("Date") == "Wed, 06 Jul 2022 16:36:09 -0400"
+    ), "`Date` header should contain raw date info."
+    assert patch.get_header("Subject") == (
+        "[PATCH] errors: add a maintenance-mode specific title to serverside error handlers "
+        "(Bug 1724769)"
+    ), "`Subject` header should contain raw subject header."
+    assert patch.get_commit_description() == (
+        "errors: add a maintenance-mode specific title to serverside error handlers "
+        "(Bug 1724769)\n\n"
+        "Adds a conditional to the Lando-API exception handlers that\n"
+        "shows a maintenance-mode specific title when a 503 error is\n"
+        "returned from Lando. This should inform users that Lando is\n"
+        "unavailable at the moment and is not broken."
+    ), "`commit_description()` should return full commit message."
+    assert patch.get_diff() == "", "`get_diff()` should return an empty string."


### PR DESCRIPTION
When empty Git commits are sent to Lando in `git format-patch`
format, Lando fails to parse the commit correctly. Currently
Lando will fail to find the `---` line used to separate the
commit message from the diff, and assume all lines in the
patch body are part of the commit message. The parsing will
then fail later down the line as Lando will not find a valid
diff line in the body.

Add an `else` clause to the loop which looks for the `---` line
separating the extended commit message and the diff, which when
reached indicates that no diff is present on the commit. In this
case we strip the last two lines of the gathered commit message
and return an empty diff. Add a test for parsing a patch generated
from an empty commit to `test_hgexports.py`.
