### PR TITLE
uplifts: query `differential.querydiffs` to find the latest non-`commit` diff (Bug 1709608)

### DIFF
--- a/landoapi/api/uplift.py
+++ b/landoapi/api/uplift.py
@@ -13,6 +13,7 @@ from landoapi.phabricator import PhabricatorClient
 from landoapi.repos import get_repos_for_env
 from landoapi.uplift import (
     create_uplift_revision,
+    get_latest_good_binary_diff,
     get_local_uplift_repo,
     get_uplift_conduit_state,
     get_uplift_repositories,
@@ -67,7 +68,12 @@ def create(phab: PhabricatorClient, data: dict):
                 "target_repository": repo_name,
             },
         )
-        revision_data, revision_stack, target_repository = get_uplift_conduit_state(
+        (
+            revision_data,
+            revision_stack,
+            target_repository,
+            rev_ids_to_all_diffs,
+        ) = get_uplift_conduit_state(
             phab,
             revision_id=revision_id,
             target_repository_name=repo_name,
@@ -103,8 +109,7 @@ def create(phab: PhabricatorClient, data: dict):
         revision = revision_data.revisions[phid]
 
         # Get the relevant diff.
-        diff_phid = phab.expect(revision, "fields", "diffPHID")
-        diff = revision_data.diffs[diff_phid]
+        diff = get_latest_good_binary_diff(rev_ids_to_all_diffs[revision["id"]])
 
         # Get the parent commit PHID from the stack if available.
         parent_phid = commit_stack[-1]["revision_phid"] if commit_stack else None

--- a/landoapi/api/uplift.py
+++ b/landoapi/api/uplift.py
@@ -13,7 +13,7 @@ from landoapi.phabricator import PhabricatorClient
 from landoapi.repos import get_repos_for_env
 from landoapi.uplift import (
     create_uplift_revision,
-    get_latest_good_binary_diff,
+    get_latest_non_commit_diff,
     get_local_uplift_repo,
     get_uplift_conduit_state,
     get_uplift_repositories,
@@ -109,7 +109,7 @@ def create(phab: PhabricatorClient, data: dict):
         revision = revision_data.revisions[phid]
 
         # Get the relevant diff.
-        diff = get_latest_good_binary_diff(rev_ids_to_all_diffs[revision["id"]])
+        diff = get_latest_non_commit_diff(rev_ids_to_all_diffs[revision["id"]])
 
         # Get the parent commit PHID from the stack if available.
         parent_phid = commit_stack[-1]["revision_phid"] if commit_stack else None

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -101,7 +101,7 @@ def get_rev_ids_to_diffs(phab: PhabricatorClient, rev_ids: list[int]) -> dict:
     """Given the list of revision ids, return a mapping of IDs to all associated diffs."""
     # Query all diffs for the revisions with `differential.querydiffs`.
     querydiffs_response = phab.call_conduit(
-        "differential.diff.search", constraints={"revisionIDs": rev_ids}
+        "differential.querydiffs", constraints={"revisionIDs": rev_ids}
     )
 
     rev_ids_to_all_diffs = collections.defaultdict(list)

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -168,7 +168,7 @@ def get_uplift_conduit_state(
     return stack_data, stack, target_repo, rev_ids_to_all_diffs
 
 
-def get_latest_good_binary_diff(diffs: list[dict]) -> dict:
+def get_latest_non_commit_diff(diffs: list[dict]) -> dict:
     """Given a list of diff dicts, return the latest diff that avoids bug 1865760."""
     # Iterate through the diffs in order of the latest IDs.
     for diff in sorted(diffs, key=itemgetter("id"), reverse=True):

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -171,7 +171,12 @@ def get_uplift_conduit_state(
 
 
 def get_latest_non_commit_diff(diffs: list[dict]) -> dict:
-    """Given a list of diff dicts, return the latest diff that avoids bug 1865760."""
+    """Given a list of diff dicts, return the latest diff with a non-commit creation method.
+
+    Commits with a `creationMethod` of `commit` will have empty binary files, if any
+    are included in the commit. Avoid using them for creating uplift requests and instead
+    use the latest non-commit diff associated with the patch. See bug 1865760 for more.
+    """
     # Iterate through the diffs in order of the latest IDs.
     for diff in sorted(diffs, key=itemgetter("id"), reverse=True):
         # Diffs with a `creationMethod` of `commit` may have bad binary data.

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -97,7 +97,9 @@ def get_revisions_without_bugs(phab: PhabricatorClient, revisions: dict) -> set[
     return missing_bugs
 
 
-def get_rev_ids_to_diffs(phab: PhabricatorClient, rev_ids: list[int]) -> dict:
+def get_rev_ids_to_diffs(
+    phab: PhabricatorClient, rev_ids: list[int]
+) -> dict[int, list[dict]]:
     """Given the list of revision ids, return a mapping of IDs to all associated diffs."""
     # Query all diffs for the revisions with `differential.querydiffs`.
     querydiffs_response = phab.call_conduit(
@@ -107,7 +109,7 @@ def get_rev_ids_to_diffs(phab: PhabricatorClient, rev_ids: list[int]) -> dict:
     rev_ids_to_all_diffs = collections.defaultdict(list)
     for diff in querydiffs_response.values():
         rev_id = phab.expect(diff, "revisionID")
-        rev_ids_to_all_diffs[rev_id].append(diff)
+        rev_ids_to_all_diffs[int(rev_id)].append(diff)
 
     return rev_ids_to_all_diffs
 

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -101,7 +101,7 @@ def get_rev_ids_to_diffs(phab: PhabricatorClient, rev_ids: list[int]) -> dict:
     """Given the list of revision ids, return a mapping of IDs to all associated diffs."""
     # Query all diffs for the revisions with `differential.querydiffs`.
     querydiffs_response = phab.call_conduit(
-        "differential.querydiffs", constraints={"revisionIDs": rev_ids}
+        "differential.querydiffs", revisionIDs=rev_ids
     )
 
     rev_ids_to_all_diffs = collections.defaultdict(list)

--- a/tests/test_phabricator_patch.py
+++ b/tests/test_phabricator_patch.py
@@ -18,6 +18,6 @@ def test_patch_to_changes(patch_directory, patch_name):
     patch_path = os.path.join(patch_directory, f"{patch_name}.diff")
     result_path = os.path.join(patch_directory, f"{patch_name}.json")
     with open(patch_path) as p:
-        output = patch_to_changes(p.read(), "deadbeef123")
+        output = patch_to_changes({}, p.read(), "deadbeef123")
 
     assert output == json.load(open(result_path))

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -16,6 +16,7 @@ from landoapi.stacks import (
 from landoapi.uplift import (
     add_original_revision_line_if_needed,
     create_uplift_bug_update_payload,
+    get_latest_good_binary_diff,
     get_revisions_without_bugs,
     parse_milestone_version,
     strip_depends_on_from_commit_message,
@@ -389,3 +390,22 @@ def test_get_revisions_without_bugs(phabdouble):
     assert get_revisions_without_bugs(phab, revisions) == {
         rev2["id"]
     }, "Revision without associated bug should be returned."
+
+
+def test_get_latest_good_binary_diff():
+    test_data = [
+        {"creationMethod": "commit", "id": 3},
+        {"creationMethod": "moz-phab-hg", "id": 1},
+        {"creationMethod": "commit", "id": 4},
+        {"creationMethod": "moz-phab-hg", "id": 2},
+        {"creationMethod": "commit", "id": 5},
+    ]
+
+    diff = get_latest_good_binary_diff(test_data)
+
+    assert (
+        diff["id"] == 2
+    ), "Returned diff should have the highest diff ID without `commit`."
+    assert (
+        diff["creationMethod"] != "commit"
+    ), "Diffs with a `creationMethod` of `commit` should be skipped."

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -16,7 +16,7 @@ from landoapi.stacks import (
 from landoapi.uplift import (
     add_original_revision_line_if_needed,
     create_uplift_bug_update_payload,
-    get_latest_good_binary_diff,
+    get_latest_non_commit_diff,
     get_revisions_without_bugs,
     parse_milestone_version,
     strip_depends_on_from_commit_message,
@@ -392,7 +392,7 @@ def test_get_revisions_without_bugs(phabdouble):
     }, "Revision without associated bug should be returned."
 
 
-def test_get_latest_good_binary_diff():
+def test_get_latest_non_commit_diff():
     test_data = [
         {"creationMethod": "commit", "id": 3},
         {"creationMethod": "moz-phab-hg", "id": 1},
@@ -401,7 +401,7 @@ def test_get_latest_good_binary_diff():
         {"creationMethod": "commit", "id": 5},
     ]
 
-    diff = get_latest_good_binary_diff(test_data)
+    diff = get_latest_non_commit_diff(test_data)
 
     assert (
         diff["id"] == 2


### PR DESCRIPTION
Extend `get_uplift_conduit_state` to also query `differential.querydiffs`
and return all known diffs associated with the selected uplift
revisions. When creating the uplift revisions, add a function to
parse through the diffs and return the latest diff that does not
have a `creationMethod` of `commit`. This works around an issue
in Phabricator where diffs are created with empty binary files
when a new diff is created after parsing a commit from the observed
version control repository.
