### PR TITLE
fix(circleci): Using CIRCLE_TAG in develop and stage image tags (bug 1870070)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,12 @@ jobs:
                 docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
               elif [[ ${CIRCLE_BRANCH} == develop ]]; then
                 docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:develop-latest"
-                docker push "${DOCKERHUB_REPO}:develop-latest"
+                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:develop-${CIRCLE_TAG}"
+                docker push "${DOCKERHUB_REPO}:develop-${CIRCLE_TAG}"
               elif [[ ${CIRCLE_BRANCH} == staging ]]; then
                 docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:staging-latest"
-                docker push "${DOCKERHUB_REPO}:staging-latest"
+                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:staging-${CIRCLE_TAG}"
+                docker push "${DOCKERHUB_REPO}:staging-${CIRCLE_TAG}"
               fi
             fi
 


### PR DESCRIPTION
Using CIRCLE_TAG in development and staging image tags to build immutable tags for deployment. 