### PR TITLE
fix: Using SHA1 in dev/stage image name instead of tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,12 @@ jobs:
                 docker push "${DOCKERHUB_REPO}:${CIRCLE_TAG}"
               elif [[ ${CIRCLE_BRANCH} == develop ]]; then
                 docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:develop-${CIRCLE_TAG}"
-                docker push "${DOCKERHUB_REPO}:develop-${CIRCLE_TAG}"
+                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:develop-${CIRCLE_SHA1}"
+                docker push "${DOCKERHUB_REPO}:develop-${CIRCLE_SHA1}"
               elif [[ ${CIRCLE_BRANCH} == staging ]]; then
                 docker login -u "$DOCKER_USER" -p "$DOCKER_PASS"
-                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:staging-${CIRCLE_TAG}"
-                docker push "${DOCKERHUB_REPO}:staging-${CIRCLE_TAG}"
+                docker tag "mozilla/landoapi" "${DOCKERHUB_REPO}:staging-${CIRCLE_SHA1}"
+                docker push "${DOCKERHUB_REPO}:staging-${CIRCLE_SHA1}"
               fi
             fi
 


### PR DESCRIPTION
`CIRCLE_TAG` is not populated when we want to create dev and stage images.

Using `CIRCLE_SHA1` instead of `CIRCLE_TAG` for dev and stage tag names
