### PR TITLE
git: scan end of patch for `--` instead of assuming last two lines (Bug 1856590)

### DIFF
--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -96,7 +96,9 @@ index f56ba1c..33391ea 100644
          500,
 --
 2.31.1
-""".strip()
+
+
+""".lstrip()
 
 GIT_PATCH_ONLY_DIFF = """diff --git a/landoui/errorhandlers.py b/landoui/errorhandlers.py
 index f56ba1c..33391ea 100644
@@ -413,3 +415,19 @@ def test_git_formatpatch_helper_empty_commit():
         "unavailable at the moment and is not broken."
     ), "`commit_description()` should return full commit message."
     assert patch.get_diff() == "", "`get_diff()` should return an empty string."
+
+
+def test_strip_git_version_info_lines():
+    lines = [
+        "blah",
+        "blah",
+        "--",
+        "git version info",
+        "",
+        "",
+    ]
+
+    assert GitPatchHelper.strip_git_version_info_lines(lines) == [
+        "blah",
+        "blah",
+    ]


### PR DESCRIPTION
Some patches sent with Git will include whitespace at the end of the
patch, meaning the Git version info is the last 3 lines instead of
2. Add a function which scans the lines in reverse and looks for
the first line beginning with `--` instead of using a naive slice
that removes the last two lines of output.

Update the Git parsing test to include extra lines of whitespace
to account for this change in the main tests for `GitPatchParser`.
Also add a simple test for the new parsing function.
