### PR TITLE
hg: change push failure snippet to be more pushlog specific (Bug 1877451)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -99,7 +99,7 @@ class HgmoInternalServerError(HgException):
 
     SNIPPETS = (
         b"abort: HTTP Error 500:",
-        b"abort: push failed on remote",
+        b"remote: could not complete push due to pushlog operational errors",
     )
 
 

--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -95,7 +95,7 @@ class PushTimeoutException(HgException):
 
 
 class HgmoInternalServerError(HgException):
-    """Exception when pulling changes from the upstream repo fails."""
+    """Exception that occurs when hg.mozilla.org encounters a server-side error."""
 
     SNIPPETS = (
         b"abort: HTTP Error 500:",

--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -99,6 +99,7 @@ class HgmoInternalServerError(HgException):
 
     SNIPPETS = (
         b"abort: HTTP Error 500:",
+        b"remote: Connection to hg.mozilla.org closed by remote host",
         b"remote: could not complete push due to pushlog operational errors",
     )
 

--- a/tests/test_hg.py
+++ b/tests/test_hg.py
@@ -236,6 +236,10 @@ def test_hg_exceptions():
         b"unresolved conflicts (see hg resolve": PatchConflict,
         b"timed out waiting for lock held by": PushTimeoutException,
         b"abort: HTTP Error 500: Internal Server Error": HgmoInternalServerError,
+        (
+            b"remote: could not complete push due to pushlog operational errors; "
+            b"please retry, and file a bug if the issue persists"
+        ): HgmoInternalServerError,
     }
 
     for snippet, exception in snippet_exception_mapping.items():


### PR DESCRIPTION
In bug 1864463 we added a snippet so pushlog operational failures in
hgmo resulted in a retry instead of a permanent failure of the landing
job. The snippet we check for was the very generic `abort: push failed
on remote`, which is actually an error message seen for many other
failures, including problems with the patch that will always cause
the push to be rejected.

Remove the generic snippet and replace with a more specific error about
pushlog operational failures.
