### PR TITLE
transplants: remove unused token comparison mocking shim

### DIFF
--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -50,15 +50,6 @@ RevisionWarning = namedtuple(
 CODE_FREEZE_OFFSET = "-0800"
 
 
-def tokens_are_equal(t1, t2):
-    """Return whether t1 and t2 are equal.
-
-    This function exists to make mocking or ignoring confirmation token
-    checks very simple.
-    """
-    return t1 == t2
-
-
 class TransplantAssessment:
     """Represents an assessment of issues that may block a revision landing.
 
@@ -120,7 +111,7 @@ class TransplantAssessment:
             )
 
         details = self.to_dict()
-        if not tokens_are_equal(details["confirmation_token"], confirmation_token):
+        if not details["confirmation_token"] == confirmation_token:
             if confirmation_token is None:
                 raise ProblemException(
                     400,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ from landoapi.projects import (
 from landoapi.repos import SCM_LEVEL_1, SCM_LEVEL_3, Repo
 from landoapi.storage import db as _db
 from landoapi.tasks import celery
-from landoapi.transplants import CODE_FREEZE_OFFSET, tokens_are_equal
+from landoapi.transplants import CODE_FREEZE_OFFSET
 from tests.mocks import PhabricatorDouble, TreeStatusDouble
 
 PATCH_NORMAL_1 = r"""
@@ -336,21 +336,6 @@ def mocked_repo_config(mock_repo_config):
             }
         }
     )
-
-
-@pytest.fixture
-def set_confirmation_token_comparison(monkeypatch):
-    mem = {"set": False, "val": None}
-
-    def set_value(val):
-        mem["set"] = True
-        mem["val"] = val
-
-    monkeypatch.setattr(
-        "landoapi.transplants.tokens_are_equal",
-        lambda t1, t2: mem["val"] if mem["set"] else tokens_are_equal(t1, t2),
-    )
-    return set_value
 
 
 @pytest.fixture


### PR DESCRIPTION
`transplants.py` has a function for comparing the equality of two
confirmation tokens that is a simple wrapper around `==` to allow
for easy replication of unequal tokens in test conditions. However,
the pytext fixture which is hooked into this shim is unused. Remove
the shim and replace the function with a simple `==` comparison.
