### PR TITLE
hg: run a specific subset of formatters for autoformatting (Bug 1871425)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -422,7 +422,18 @@ class HgRepo:
         Changes made by code formatters are applied to the working directory and
         are not committed into version control.
         """
-        return self.run_mach_command(["lint", "--fix", "--outgoing", "--verbose"])
+        supported_formatters = [
+            "black",
+            "clang-format",
+            "eslint",
+            "rustfmt",
+        ]
+
+        linter_args = [f"--linter={formatter}" for formatter in supported_formatters]
+
+        return self.run_mach_command(
+            ["lint", *linter_args, "--fix", "--outgoing", "--verbose"]
+        )
 
     def run_mach_bootstrap(self) -> str:
         """Run `mach bootstrap` to configure the system for code formatting."""


### PR DESCRIPTION
Due to the WPT linter breaking in a way that is difficult to debug,
we have had autoformatting disabled in Lando for a short while. There
are still some blockers with bug 1807712 that mean we can't directly
move to `mach format`. In the meantime, to re-enable autoformatting,
add an explicit allow list for formatters which will run in Lando
and update the call to `mach lint` to use them.
