### PR TITLE
revisions: block revisions with `needs-data-classification` tag from landing (Bug 1880861)

### DIFF
--- a/landoapi/api/stacks.py
+++ b/landoapi/api/stacks.py
@@ -12,6 +12,7 @@ from landoapi.decorators import require_phabricator_api_key
 from landoapi.models.revisions import Revision
 from landoapi.phabricator import PhabricatorClient
 from landoapi.projects import (
+    get_data_policy_review_phid,
     get_release_managers,
     get_sec_approval_project_phid,
     get_secure_project_phid,
@@ -82,9 +83,16 @@ def get(phab: PhabricatorClient, revision_id: str):
     if not release_managers:
         raise Exception("Could not find `#release-managers` project on Phabricator.")
 
+    data_policy_review_phid = get_data_policy_review_phid(phab)
+    if not data_policy_review_phid:
+        raise Exception(
+            "Could not find `#needs-data-classification` project on Phabricator."
+        )
+
     relman_group_phid = str(phab.expect(release_managers, "phid"))
 
     other_checks = get_blocker_checks(
+        data_policy_review_phid=data_policy_review_phid,
         relman_group_phid=relman_group_phid,
         repositories=supported_repos,
         stack_data=stack_data,

--- a/landoapi/projects.py
+++ b/landoapi/projects.py
@@ -33,6 +33,9 @@ SEC_APPROVAL_PROJECT_SLUG = "sec-approval"
 # Management team, to approve uplift requests
 RELMAN_PROJECT_SLUG = "release-managers"
 
+# The name of the Phabricator project used to tag revisions requiring data classification.
+NEEDS_DATA_CLASSIFICATION_SLUG = "needs-data-classification"
+
 
 def project_search(
     phabricator: PhabricatorClient, project_phids: list[str]
@@ -139,3 +142,8 @@ def get_release_managers(phab: PhabricatorClient) -> Optional[dict]:
         constraints={"slugs": [RELMAN_PROJECT_SLUG]},
     )
     return phab.single(groups, "data")
+
+
+def get_data_policy_review_phid(phab: PhabricatorClient) -> Optional[str]:
+    """Return the PHID for the `#needs-data-classification` project."""
+    return get_project_phid(NEEDS_DATA_CLASSIFICATION_SLUG, phab)

--- a/landoapi/revisions.py
+++ b/landoapi/revisions.py
@@ -132,7 +132,7 @@ def check_diff_author_is_known(*, diff: dict, **kwargs) -> Optional[str]:
     )
 
 
-def revision_has_needs_data_classification(
+def revision_has_needs_data_classification_tag(
     revision: dict, data_policy_review_phid: str
 ) -> bool:
     """Return `True` if the `needs-data-classification` tag is not present on a revision."""
@@ -145,7 +145,9 @@ def check_revision_data_classification(data_policy_review_phid: str) -> Callable
     """Check that the `needs-data-classification` tag is not present on a revision."""
 
     def _check(revision: dict, **kwargs) -> Optional[str]:
-        if revision_has_needs_data_classification(revision, data_policy_review_phid):
+        if revision_has_needs_data_classification_tag(
+            revision, data_policy_review_phid
+        ):
             return (
                 "Revision makes changes to data collection and "
                 "should have its data classification assessed before landing."

--- a/landoapi/revisions.py
+++ b/landoapi/revisions.py
@@ -132,6 +132,28 @@ def check_diff_author_is_known(*, diff: dict, **kwargs) -> Optional[str]:
     )
 
 
+def revision_has_needs_data_classification(
+    revision: dict, data_policy_review_phid: str
+) -> bool:
+    """Return `True` if the `needs-data-classification` tag is not present on a revision."""
+    return (
+        data_policy_review_phid in revision["attachments"]["projects"]["projectPHIDs"]
+    )
+
+
+def check_revision_data_classification(data_policy_review_phid: str) -> Callable:
+    """Check that the `needs-data-classification` tag is not present on a revision."""
+
+    def _check(revision: dict, **kwargs) -> Optional[str]:
+        if revision_has_needs_data_classification(revision, data_policy_review_phid):
+            return (
+                "Revision makes changes to data collection and "
+                "should have its data classification assessed before landing."
+            )
+
+    return _check
+
+
 def check_author_planned_changes(*, revision, **kwargs):
     status = PhabricatorRevisionStatus.from_status(
         PhabricatorClient.expect(revision, "fields", "status", "value")

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -24,6 +24,7 @@ from landoapi.reviews import calculate_review_extra_state, reviewer_identity
 from landoapi.revisions import (
     check_author_planned_changes,
     check_diff_author_is_known,
+    check_revision_data_classification,
     check_uplift_approval,
     revision_is_secure,
     revision_needs_testing_tag,
@@ -517,14 +518,19 @@ def check_landing_blockers(
 
 
 def get_blocker_checks(
-    repositories: dict, relman_group_phid: str, stack_data: RevisionData
+    repositories: dict,
+    relman_group_phid: str,
+    stack_data: RevisionData,
+    data_policy_review_phid: str,
 ):
     """Build all transplant blocker checks that need extra Phabricator data"""
     assert all((isinstance(r, Repo) for r in repositories.values()))
 
     return DEFAULT_OTHER_BLOCKER_CHECKS + [
         # Configure uplift check with extra data.
-        check_uplift_approval(relman_group_phid, repositories, stack_data)
+        check_uplift_approval(relman_group_phid, repositories, stack_data),
+        # Configure data policy check with the project PHID.
+        check_revision_data_classification(data_policy_review_phid),
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from landoapi.mocks.auth import TEST_JWKS, MockAuth0
 from landoapi.phabricator import PhabricatorClient
 from landoapi.projects import (
     CHECKIN_PROJ_SLUG,
+    NEEDS_DATA_CLASSIFICATION_SLUG,
     RELMAN_PROJECT_SLUG,
     SEC_APPROVAL_PROJECT_SLUG,
     SEC_PROJ_SLUG,
@@ -209,6 +210,11 @@ def release_management_project(phabdouble):
         RELMAN_PROJECT_SLUG,
         attachments={"members": {"members": [{"phid": "PHID-USER-1"}]}},
     )
+
+
+@pytest.fixture
+def needs_data_classification_project(phabdouble):
+    return phabdouble.project(NEEDS_DATA_CLASSIFICATION_SLUG)
 
 
 @pytest.fixture

--- a/tests/test_reviews.py
+++ b/tests/test_reviews.py
@@ -95,7 +95,9 @@ def test_sec_approval_is_filtered_from_commit_message_reviewer_list(
 
 
 def test_approvals_for_commit_message(
-    phabdouble, sec_approval_project, release_management_project
+    phabdouble,
+    sec_approval_project,
+    release_management_project,
 ):
     revision = phabdouble.revision()
     user = phabdouble.user(username="normal_reviewer")

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -9,6 +9,7 @@ from landoapi.repos import get_repos_for_env
 from landoapi.revisions import (
     check_author_planned_changes,
     check_diff_author_is_known,
+    check_revision_data_classification,
     check_uplift_approval,
     revision_is_secure,
     revision_needs_testing_tag,
@@ -63,7 +64,12 @@ def test_check_author_planned_changes_changes_planned(phabdouble):
 
 
 def test_secure_api_flag_on_public_revision_is_false(
-    db, client, phabdouble, release_management_project, sec_approval_project
+    db,
+    client,
+    phabdouble,
+    release_management_project,
+    needs_data_classification_project,
+    sec_approval_project,
 ):
     repo = phabdouble.repo(name="test-repo")
     public_project = phabdouble.project("public")
@@ -82,6 +88,7 @@ def test_secure_api_flag_on_secure_revision_is_true(
     phabdouble,
     secure_project,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     repo = phabdouble.repo(name="test-repo")
@@ -111,7 +118,9 @@ def test_secure_revision_is_secure(phabdouble, secure_project):
     assert revision_is_secure(revision, secure_project["phid"])
 
 
-def test_relman_approval_missing(phabdouble, release_management_project):
+def test_relman_approval_missing(
+    phabdouble, release_management_project, needs_data_classification_project
+):
     """A repo with an approval required needs relman as reviewer"""
     repo = phabdouble.repo(name="uplift-target")
     repos = get_repos_for_env("localdev")
@@ -126,7 +135,11 @@ def test_relman_approval_missing(phabdouble, release_management_project):
     phab_client = phabdouble.get_phabricator_client()
     stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
 
-    check = check_uplift_approval(release_management_project["phid"], repos, stack_data)
+    check = check_uplift_approval(
+        release_management_project["phid"],
+        repos,
+        stack_data,
+    )
     assert check(revision=phab_revision, repo=phabdouble.api_object_for(repo)) == (
         "The release-managers group did not accept the stack: "
         "you need to wait for a group approval from release-managers, "
@@ -135,7 +148,9 @@ def test_relman_approval_missing(phabdouble, release_management_project):
 
 
 @pytest.mark.parametrize("status", list(ReviewerStatus))
-def test_relman_approval_status(status, phabdouble, release_management_project):
+def test_relman_approval_status(
+    status, phabdouble, release_management_project, needs_data_classification_project
+):
     """Check only an approval from relman allows landing"""
     repo = phabdouble.repo(name="uplift-target")
     repos = get_repos_for_env("localdev")
@@ -143,7 +158,11 @@ def test_relman_approval_status(status, phabdouble, release_management_project):
 
     # Add relman as reviewer with specified status
     revision = phabdouble.revision(repo=repo, uplift="blah blah")
-    phabdouble.reviewer(revision, release_management_project, status=status)
+    phabdouble.reviewer(
+        revision,
+        release_management_project,
+        status=status,
+    )
 
     # Add a some extra reviewers
     for i in range(3):
@@ -157,7 +176,11 @@ def test_relman_approval_status(status, phabdouble, release_management_project):
     phab_client = phabdouble.get_phabricator_client()
     stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
 
-    check = check_uplift_approval(release_management_project["phid"], repos, stack_data)
+    check = check_uplift_approval(
+        release_management_project["phid"],
+        repos,
+        stack_data,
+    )
     output = check(revision=phab_revision, repo=phabdouble.api_object_for(repo))
     if status == ReviewerStatus.ACCEPTED:
         assert output is None
@@ -193,3 +216,34 @@ def test_repo_does_not_have_testing_policy(phabdouble):
     assert not revision_needs_testing_tag(
         revision, repo, ["testing-tag-phid"], "testing-policy-phid"
     )
+
+
+def test_revision_has_data_classification_tag(
+    phabdouble, needs_data_classification_project
+):
+    repo = phabdouble.repo()
+    revision = phabdouble.revision(
+        repo=repo, projects=[needs_data_classification_project]
+    )
+    phab_revision = phabdouble.api_object_for(
+        revision,
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+    )
+
+    check = check_revision_data_classification(
+        needs_data_classification_project["phid"]
+    )
+
+    assert check(revision=phab_revision, repo=phabdouble.api_object_for(repo)) == (
+        "Revision makes changes to data collection and "
+        "should have its data classification assessed before landing."
+    ), "Revision with data classification project tag should be blocked from landing."
+
+    revision = phabdouble.revision(repo=repo)
+    phab_revision = phabdouble.api_object_for(
+        revision,
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+    )
+    assert (
+        check(revision=phab_revision, repo=phabdouble.api_object_for(repo)) is None
+    ), "Revision with no data classification tag should not be blocked from landing."

--- a/tests/test_sanitized_commit_messages.py
+++ b/tests/test_sanitized_commit_messages.py
@@ -86,6 +86,7 @@ def test_integrated_secure_stack_has_alternate_commit_message(
     authed_headers,
     monkeypatch,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     sanitized_title = "my secure commit title"
@@ -120,6 +121,7 @@ def test_integrated_secure_stack_without_sec_approval_does_not_use_secure_messag
     mock_repo_config,
     secure_project,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     # Build a plain old secure revision, no sec-approval requests made.
@@ -145,6 +147,7 @@ def test_integrated_sec_approval_transplant_uses_alternate_message(
     monkeypatch,
     authed_headers,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     sanitized_title = "my secure commit title"
@@ -213,6 +216,7 @@ def test_integrated_sec_approval_problem_halts_landing(
     monkeypatch,
     authed_headers,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     sanitized_title = "my secure commit title"

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -631,6 +631,7 @@ def test_integrated_stack_endpoint_simple(
     phabdouble,
     mocked_repo_config,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     repo = phabdouble.repo()
@@ -671,6 +672,7 @@ def test_integrated_stack_endpoint_repos(
     phabdouble,
     mocked_repo_config,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     repo = phabdouble.repo()
@@ -703,6 +705,7 @@ def test_integrated_stack_has_revision_security_status(
     mock_repo_config,
     secure_project,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     repo = phabdouble.repo()
@@ -725,6 +728,7 @@ def test_integrated_stack_response_mismatch_returns_404(
     phabdouble,
     mock_repo_config,
     release_management_project,
+    needs_data_classification_project,
     sec_approval_project,
 ):
     # If the API response contains a different number of revisions than the

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -100,7 +100,12 @@ def _create_landing_job_with_no_linked_revisions(
 
 
 def test_dryrun_no_warnings_or_blockers(
-    client, db, phabdouble, auth0_mock, release_management_project
+    client,
+    db,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=phabdouble.repo())
@@ -124,7 +129,12 @@ def test_dryrun_no_warnings_or_blockers(
 
 
 def test_dryrun_invalid_path_blocks(
-    client, db, phabdouble, auth0_mock, release_management_project
+    client,
+    db,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     d1 = phabdouble.diff()
     d2 = phabdouble.diff()
@@ -152,7 +162,12 @@ def test_dryrun_invalid_path_blocks(
 
 
 def test_dryrun_in_progress_transplant_blocks(
-    client, db, phabdouble, auth0_mock, release_management_project
+    client,
+    db,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     repo = phabdouble.repo()
 
@@ -199,7 +214,12 @@ def test_dryrun_in_progress_transplant_blocks(
 
 
 def test_dryrun_reviewers_warns(
-    client, db, phabdouble, auth0_mock, release_management_project
+    client,
+    db,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1, repo=phabdouble.repo())
@@ -233,6 +253,7 @@ def test_dryrun_codefreeze_warn(
     monkeypatch,
     request_mocker,
     release_management_project,
+    needs_data_classification_project,
 ):
     product_details = "https://product-details.mozilla.org/1.0/firefox_versions.json"
     request_mocker.register_uri(
@@ -291,6 +312,7 @@ def test_dryrun_outside_codefreeze(
     monkeypatch,
     request_mocker,
     release_management_project,
+    needs_data_classification_project,
 ):
     product_details = "https://product-details.mozilla.org/1.0/firefox_versions.json"
     request_mocker.register_uri(
@@ -360,6 +382,7 @@ def test_integrated_dryrun_blocks_for_bad_userinfo(
     status,
     blocker,
     release_management_project,
+    needs_data_classification_project,
 ):
     auth0_mock.userinfo = userinfo
     d1 = phabdouble.diff()
@@ -668,6 +691,7 @@ def test_integrated_transplant_simple_stack_saves_data_in_db(
     phabdouble,
     auth0_mock,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     phabrepo = phabdouble.repo(name="mozilla-central")
@@ -722,6 +746,7 @@ def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
     phabdouble,
     auth0_mock,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     phabrepo = phabdouble.repo(name="mozilla-central")
@@ -781,6 +806,7 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     treestatusdouble,
     auth0_mock,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
     monkeypatch,
     normal_patch,
@@ -865,6 +891,7 @@ def test_integrated_transplant_updated_diff_id_reflected_in_landed_revisions(
     phabdouble,
     auth0_mock,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     """
@@ -959,7 +986,13 @@ def test_integrated_transplant_updated_diff_id_reflected_in_landed_revisions(
 
 
 def test_integrated_transplant_with_flags(
-    db, client, phabdouble, auth0_mock, monkeypatch, release_management_project
+    db,
+    client,
+    phabdouble,
+    auth0_mock,
+    monkeypatch,
+    release_management_project,
+    needs_data_classification_project,
 ):
     repo = phabdouble.repo(name="mozilla-new")
     user = phabdouble.user(username="reviewer")
@@ -992,7 +1025,13 @@ def test_integrated_transplant_with_flags(
 
 
 def test_integrated_transplant_with_invalid_flags(
-    db, client, phabdouble, auth0_mock, monkeypatch, release_management_project
+    db,
+    client,
+    phabdouble,
+    auth0_mock,
+    monkeypatch,
+    release_management_project,
+    needs_data_classification_project,
 ):
     repo = phabdouble.repo(name="mozilla-new")
     user = phabdouble.user(username="reviewer")
@@ -1023,6 +1062,7 @@ def test_integrated_transplant_legacy_repo_checkin_project_removed(
     checkin_project,
     monkeypatch,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     repo = phabdouble.repo(name="mozilla-central")
@@ -1058,6 +1098,7 @@ def test_integrated_transplant_repo_checkin_project_removed(
     checkin_project,
     monkeypatch,
     release_management_project,
+    needs_data_classification_project,
 ):
     repo = phabdouble.repo(name="mozilla-new")
     user = phabdouble.user(username="reviewer")
@@ -1085,7 +1126,12 @@ def test_integrated_transplant_repo_checkin_project_removed(
 
 
 def test_integrated_transplant_without_auth0_permissions(
-    client, auth0_mock, phabdouble, db, release_management_project
+    client,
+    auth0_mock,
+    phabdouble,
+    db,
+    release_management_project,
+    needs_data_classification_project,
 ):
     auth0_mock.userinfo = CANNED_USERINFO["NO_CUSTOM_CLAIMS"]
 
@@ -1133,7 +1179,12 @@ def test_transplant_wrong_landing_path_format(db, client, auth0_mock):
 
 
 def test_integrated_transplant_diff_not_in_revision(
-    db, client, phabdouble, auth0_mock, release_management_project
+    db,
+    client,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     repo = phabdouble.repo()
     d1 = phabdouble.diff()
@@ -1155,7 +1206,12 @@ def test_integrated_transplant_diff_not_in_revision(
 
 
 def test_transplant_nonexisting_revision_returns_404(
-    db, client, phabdouble, auth0_mock, release_management_project
+    db,
+    client,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     response = client.post(
         "/transplants",
@@ -1168,7 +1224,12 @@ def test_transplant_nonexisting_revision_returns_404(
 
 
 def test_integrated_transplant_revision_with_no_repo(
-    db, client, phabdouble, auth0_mock, release_management_project
+    db,
+    client,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     d1 = phabdouble.diff()
     r1 = phabdouble.revision(diff=d1)
@@ -1190,7 +1251,12 @@ def test_integrated_transplant_revision_with_no_repo(
 
 
 def test_integrated_transplant_revision_with_unmapped_repo(
-    db, client, phabdouble, auth0_mock, release_management_project
+    db,
+    client,
+    phabdouble,
+    auth0_mock,
+    release_management_project,
+    needs_data_classification_project,
 ):
     repo = phabdouble.repo(name="notsupported")
     d1 = phabdouble.diff()
@@ -1220,6 +1286,7 @@ def test_integrated_transplant_sec_approval_group_is_excluded_from_reviewers_lis
     auth0_mock,
     sec_approval_project,
     release_management_project,
+    needs_data_classification_project,
     register_codefreeze_uri,
 ):
     repo = phabdouble.repo()
@@ -1275,6 +1342,7 @@ def test_unresolved_comment_warn(
     phabdouble,
     auth0_mock,
     release_management_project,
+    needs_data_classification_project,
 ):
     """Ensure a warning is generated when a revision has unresolved comments.
 
@@ -1346,6 +1414,7 @@ def test_unresolved_comment_stack(
     phabdouble,
     auth0_mock,
     release_management_project,
+    needs_data_classification_project,
 ):
     """
     Ensure a warning is generated when a revision in the stack has unresolved comments.

--- a/tests/test_uplift.py
+++ b/tests/test_uplift.py
@@ -99,6 +99,7 @@ def test_uplift_creation(
     auth0_mock,
     mock_repo_config,
     release_management_project,
+    needs_data_classification_project,
 ):
     def _call_conduit(client, method, **kwargs):
         if method == "differential.revision.edit":


### PR DESCRIPTION
Add a blocking check that enforces revisions with the `needs-data-classification`
tag cannot land. The check is similar to the testing policy project tag checks
except it simply looks for the `needs-data-classification` tag and
blocks landing if it is present on the revision. The tag requires the
PHID of the project tag so it is generated with a factory function in a
similar manner to the release manager approval blocking check.
