### PR TITLE
landing_job: fix ordering of jobs in queue (bug 1878666)

### DIFF
--- a/tests/test_landings.py
+++ b/tests/test_landings.py
@@ -399,6 +399,7 @@ def test_lose_push_race(
 
     assert not worker.run_job(job, repo, hgrepo, treestatus)
     assert job.status == LandingJobStatus.DEFERRED
+    assert job.priority == -1
 
 
 def test_failed_landing_job_notification(


### PR DESCRIPTION
- order first by priority, then by status and creation time
- decrease job priority by 1 when it is deferred