### PR TITLE
tests: use correct loop variable and rename to `revision`

### DIFF
--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -94,7 +94,7 @@ def _create_landing_job_with_no_linked_revisions(
     job.revision_to_diff_id = {
         str(revision.revision_id): revision.diff_id for revision in revisions
     }
-    job.revision_order = [str(revision.revision_id) for r in revisions]
+    job.revision_order = [str(revision.revision_id) for revision in revisions]
     db.session.commit()
     return job
 


### PR DESCRIPTION
In the list comprehension where we set `job.revision_order` in
`create_landing_job_with_no_linked_revisions`, we iterate over
`revisions` and set the iteration variable as `r`, but the
value that ends up in the list uses the leftover `revision`
variable from the loop iteration above. Rename `r` to `revision`
so the correct variable is used.
