### PR TITLE
repos: add `large-repo` to dev repo configs (Bug 1821153)

### DIFF
--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -220,6 +220,15 @@ REPO_CONFIG = {
             url="https://hg.mozilla.org/conduit-testing/test-repo",
             access_group=SCM_CONDUIT,
         ),
+        "large-repo": Repo(
+            tree="large-repo",
+            url="https://hg.mozilla.org/conduit-testing/m-c",
+            access_group=SCM_CONDUIT,
+            commit_flags=[DONTBUILD],
+            milestone_tracking_flag_template="cf_status_firefox{milestone}",
+            product_details_url="https://raw.githubusercontent.com/mozilla-conduit"
+            "/suite/main/docker/product-details/1.0/firefox_versions.json",
+        ),
         "m-c": Repo(
             tree="m-c",
             url="https://hg.mozilla.org/conduit-testing/m-c",


### PR DESCRIPTION
Add the existing `large-repo` Phabricator repo to Lando so patches can
be landed there for testing.
