### PR TITLE
checks: add a check to reject `try_task_config.json` outside of `try` (Bug 1895931)

### DIFF
--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -876,7 +876,7 @@ def blocker_try_task_config(
 
     for parsed in parsed_diff:
         if parsed["filename"] == "try_task_config.json":
-            return "Revision introduces the `try_task_config.json` file into a non-try repo."
+            return "Revision introduces the `try_task_config.json` file."
 
 
 STACK_BLOCKER_CHECKS = [

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -871,14 +871,6 @@ def blocker_try_task_config(
     revision: dict, diff: dict, stack_state: StackAssessmentState
 ) -> Optional[str]:
     """Block revisions which contain the `try_task_config.json` file."""
-    if (
-        stack_state.landing_assessment
-        and stack_state.landing_assessment.landing_repo
-        and stack_state.landing_assessment.landing_repo.tree == "try"
-    ):
-        # `try_task_config.json` is allowed to be pushed to try.
-        return
-
     diff_id = PhabricatorClient.expect(diff, "id")
     parsed_diff = stack_state.parsed_diffs[diff_id]
 

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1881,35 +1881,3 @@ def test_blocker_try_task_config_landing_state_non_try(
         )
         == "Revision introduces the `try_task_config.json` file into a non-try repo."
     ), "`try_task_config.json` should be rejected."
-
-
-def test_blocker_try_task_config_landing_state_try(phabdouble, mocked_repo_config):
-    repo = phabdouble.repo()
-
-    revision = phabdouble.revision(repo=repo)
-    phab_revision = phabdouble.api_object_for(
-        revision,
-        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
-    )
-    diff = phabdouble.diff(revision=revision, rawdiff=TRY_TASK_CONFIG_DIFF)
-
-    phab_client = phabdouble.get_phabricator_client()
-    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
-
-    # Parse diffs into `rs_parsepatch` format.
-    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
-
-    try_repo = get_repos_for_env("test")["try"]
-
-    stack_state = create_state(
-        stack_data=stack_data,
-        parsed_diffs=parsed_diffs,
-        landing_state=create_landing_state(landing_repo=try_repo),
-    )
-
-    assert (
-        blocker_try_task_config(
-            revision=phab_revision, diff=diff, stack_state=stack_state
-        )
-        is None
-    ), "`try_task_config.json` should not be rejected."

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1857,7 +1857,7 @@ def test_blocker_try_task_config_no_landing_state(
         blocker_try_task_config(
             revision=phab_revision, diff=diff, stack_state=stack_state
         )
-        == "Revision introduces the `try_task_config.json` file into a non-try repo."
+        == "Revision introduces the `try_task_config.json` file."
     ), "`try_task_config.json` should be rejected."
 
 
@@ -1879,5 +1879,5 @@ def test_blocker_try_task_config_landing_state_non_try(
         blocker_try_task_config(
             revision=phab_revision, diff=diff, stack_state=stack_state
         )
-        == "Revision introduces the `try_task_config.json` file into a non-try repo."
+        == "Revision introduces the `try_task_config.json` file."
     ), "`try_task_config.json` should be rejected."

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1839,7 +1839,9 @@ index 0000000..e44d36d
 """.lstrip()
 
 
-def test_blocker_try_task_config_no_landing_state(phabdouble):
+def test_blocker_try_task_config_no_landing_state(
+    phabdouble, mocked_repo_config, create_state
+):
     repo = phabdouble.repo()
 
     revision = phabdouble.revision(repo=repo)
@@ -1849,12 +1851,7 @@ def test_blocker_try_task_config_no_landing_state(phabdouble):
     )
     diff = phabdouble.diff(revision=revision, rawdiff=TRY_TASK_CONFIG_DIFF)
 
-    phab_client = phabdouble.get_phabricator_client()
-    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
-
-    # Parse diffs into `rs_parsepatch` format.
-    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
-    stack_state = create_state(stack_data=stack_data, parsed_diffs=parsed_diffs)
+    stack_state = create_state(phab_revision)
 
     assert (
         blocker_try_task_config(

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1855,4 +1855,4 @@ def test_blocker_try_task_config_landing_state_try(phabdouble, mocked_repo_confi
             revision=phab_revision, diff=diff, stack_state=stack_state
         )
         is None
-    ), "`try_task_config.json` should be rejected."
+    ), "`try_task_config.json` should not be rejected."

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -35,6 +35,7 @@ from landoapi.transplants import (
     blocker_author_planned_changes,
     blocker_prevent_symlinks,
     blocker_revision_data_classification,
+    blocker_try_task_config,
     blocker_uplift_approval,
     get_parsed_diffs,
     warning_not_accepted,
@@ -1748,3 +1749,110 @@ def test_blocker_prevent_symlinks(phabdouble):
         )
         == "Revision introduces symlinks in the files `blahfile_symlink`."
     ), "Diff with symlinks present should fail the check."
+
+
+TRY_TASK_CONFIG_DIFF = """
+diff --git a/blah.json b/blah.json
+new file mode 100644
+index 0000000..663cbc2
+--- /dev/null
++++ b/blah.json
+@@ -0,0 +1 @@
++{"123":"456"}
+diff --git a/try_task_config.json b/try_task_config.json
+new file mode 100644
+index 0000000..e44d36d
+--- /dev/null
++++ b/try_task_config.json
+@@ -0,0 +1 @@
++{"env": {"TRY_SELECTOR": "fuzzy"}, "version": 1, "tasks": ["source-test-cram-tryselect"]}
+""".lstrip()
+
+
+def test_blocker_try_task_config_no_landing_state(phabdouble):
+    repo = phabdouble.repo()
+
+    revision = phabdouble.revision(repo=repo)
+    phab_revision = phabdouble.api_object_for(
+        revision,
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+    )
+    diff = phabdouble.diff(revision=revision, rawdiff=TRY_TASK_CONFIG_DIFF)
+
+    phab_client = phabdouble.get_phabricator_client()
+    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
+
+    # Parse diffs into `rs_parsepatch` format.
+    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
+    stack_state = create_state(stack_data=stack_data, parsed_diffs=parsed_diffs)
+
+    assert (
+        blocker_try_task_config(
+            revision=phab_revision, diff=diff, stack_state=stack_state
+        )
+        == "Revision introduces the `try_task_config.json` file into a non-try repo."
+    ), "`try_task_config.json` should be rejected."
+
+
+def test_blocker_try_task_config_landing_state_non_try(phabdouble, mocked_repo_config):
+    repo = phabdouble.repo()
+
+    revision = phabdouble.revision(repo=repo)
+    phab_revision = phabdouble.api_object_for(
+        revision,
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+    )
+    diff = phabdouble.diff(revision=revision, rawdiff=TRY_TASK_CONFIG_DIFF)
+
+    phab_client = phabdouble.get_phabricator_client()
+    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
+
+    # Parse diffs into `rs_parsepatch` format.
+    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
+
+    mc_repo = get_repos_for_env("test")["mozilla-central"]
+
+    stack_state = create_state(
+        stack_data=stack_data,
+        parsed_diffs=parsed_diffs,
+        landing_state=create_landing_state(landing_repo=mc_repo),
+    )
+
+    assert (
+        blocker_try_task_config(
+            revision=phab_revision, diff=diff, stack_state=stack_state
+        )
+        == "Revision introduces the `try_task_config.json` file into a non-try repo."
+    ), "`try_task_config.json` should be rejected."
+
+
+def test_blocker_try_task_config_landing_state_try(phabdouble, mocked_repo_config):
+    repo = phabdouble.repo()
+
+    revision = phabdouble.revision(repo=repo)
+    phab_revision = phabdouble.api_object_for(
+        revision,
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+    )
+    diff = phabdouble.diff(revision=revision, rawdiff=TRY_TASK_CONFIG_DIFF)
+
+    phab_client = phabdouble.get_phabricator_client()
+    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
+
+    # Parse diffs into `rs_parsepatch` format.
+    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
+
+    try_repo = get_repos_for_env("test")["try"]
+
+    stack_state = create_state(
+        stack_data=stack_data,
+        parsed_diffs=parsed_diffs,
+        landing_state=create_landing_state(landing_repo=try_repo),
+    )
+
+    assert (
+        blocker_try_task_config(
+            revision=phab_revision, diff=diff, stack_state=stack_state
+        )
+        is None
+    ), "`try_task_config.json` should be rejected."

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1864,7 +1864,9 @@ def test_blocker_try_task_config_no_landing_state(phabdouble):
     ), "`try_task_config.json` should be rejected."
 
 
-def test_blocker_try_task_config_landing_state_non_try(phabdouble, mocked_repo_config):
+def test_blocker_try_task_config_landing_state_non_try(
+    phabdouble, mocked_repo_config, create_state
+):
     repo = phabdouble.repo()
 
     revision = phabdouble.revision(repo=repo)
@@ -1874,19 +1876,7 @@ def test_blocker_try_task_config_landing_state_non_try(phabdouble, mocked_repo_c
     )
     diff = phabdouble.diff(revision=revision, rawdiff=TRY_TASK_CONFIG_DIFF)
 
-    phab_client = phabdouble.get_phabricator_client()
-    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
-
-    # Parse diffs into `rs_parsepatch` format.
-    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
-
-    mc_repo = get_repos_for_env("test")["mozilla-central"]
-
-    stack_state = create_state(
-        stack_data=stack_data,
-        parsed_diffs=parsed_diffs,
-        landing_state=create_landing_state(landing_repo=mc_repo),
-    )
+    stack_state = create_state(phab_revision)
 
     assert (
         blocker_try_task_config(


### PR DESCRIPTION
Add a blocking check that asserts the `try_task_config.json` file is not
introduced erroneously to a non-try repo.
