### PR TITLE
checks: split `assess_stack_state` into a state builder and check runner (Bug 1896501)

### DIFF
--- a/landoapi/api/transplants.py
+++ b/landoapi/api/transplants.py
@@ -55,7 +55,8 @@ from landoapi.tasks import admin_remove_phab_project
 from landoapi.transplants import (
     LandingAssessmentState,
     StackAssessment,
-    assess_stack_state,
+    build_stack_assessment_state,
+    run_landing_checks,
 )
 from landoapi.users import user_search
 from landoapi.validation import (
@@ -151,7 +152,7 @@ def dryrun(phab: PhabricatorClient, data: dict):
     landing_assessment = LandingAssessmentState.from_landing_path(
         landing_path, stack_data, g.auth0_user
     )
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         stack_data,
@@ -160,6 +161,7 @@ def dryrun(phab: PhabricatorClient, data: dict):
         data_policy_review_phid,
         landing_assessment=landing_assessment,
     )
+    assessment = run_landing_checks(stack_state)
     return assessment.to_dict()
 
 
@@ -201,7 +203,7 @@ def post(phab: PhabricatorClient, data: dict):
     landing_assessment = LandingAssessmentState.from_landing_path(
         landing_path, stack_data, g.auth0_user
     )
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         stack_data,
@@ -210,6 +212,7 @@ def post(phab: PhabricatorClient, data: dict):
         data_policy_review_phid,
         landing_assessment=landing_assessment,
     )
+    assessment = run_landing_checks(stack_state)
     to_land, landing_repo = (
         landing_assessment.to_land,
         landing_assessment.landing_repo,

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -962,7 +962,7 @@ def get_parsed_diffs(
     }
 
 
-def assess_stack_state(
+def build_stack_assessment_state(
     phab: PhabricatorClient,
     supported_repos: dict[str, Repo],
     stack_data: RevisionData,
@@ -970,13 +970,8 @@ def assess_stack_state(
     relman_group_phid: str,
     data_policy_review_phid: str,
     landing_assessment: Optional[LandingAssessmentState] = None,
-) -> tuple[StackAssessment, StackAssessmentState]:
-    """Assess the state of a given stack.
-
-    Given the required state information for a stack, build a `StackAssessmentState`
-    and run stack checks, returning a `StackAssessment` and the built
-    `StackAssessmentState`.
-    """
+) -> StackAssessmentState:
+    """Given the required state information for a stack, build a `StackAssessmentState`"""
     landable_repos = get_landable_repos_for_revision_data(stack_data, supported_repos)
 
     # Retrieve and parse diffs from Phabricator.
@@ -1014,10 +1009,7 @@ def assess_stack_state(
         testing_policy_phid=testing_policy_phid,
         landing_assessment=landing_assessment,
     )
-    # Where we check the landing blockers.
-    assessment = run_landing_checks(stack_state)
-
-    return assessment, stack_state
+    return stack_state
 
 
 def convert_path_id_to_phid(

--- a/tests/test_stacks.py
+++ b/tests/test_stacks.py
@@ -12,7 +12,7 @@ from landoapi.stacks import (
     get_landable_repos_for_revision_data,
     request_extended_revision_data,
 )
-from landoapi.transplants import assess_stack_state
+from landoapi.transplants import build_stack_assessment_state, run_landing_checks
 
 
 def test_build_stack_graph_single_node(phabdouble):
@@ -293,7 +293,7 @@ def test_calculate_landable_subgraphs_no_edges_open(
 
     nodes, edges = build_stack_graph(revision_obj)
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -301,6 +301,7 @@ def test_calculate_landable_subgraphs_no_edges_open(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
 
     assert len(landable) == 1
@@ -323,7 +324,7 @@ def test_calculate_landable_subgraphs_no_edges_closed(
 
     nodes, edges = build_stack_graph(revision_obj)
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -331,6 +332,7 @@ def test_calculate_landable_subgraphs_no_edges_closed(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
 
     assert not landable
@@ -352,7 +354,7 @@ def test_calculate_landable_subgraphs_closed_root(
 
     nodes, edges = build_stack_graph(revision_obj)
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -360,6 +362,7 @@ def test_calculate_landable_subgraphs_closed_root(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
     assert landable == [[r2["phid"]]]
 
@@ -384,7 +387,7 @@ def test_calculate_landable_subgraphs_closed_root_child_merges(
 
     nodes, edges = build_stack_graph(revision_obj)
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -392,6 +395,7 @@ def test_calculate_landable_subgraphs_closed_root_child_merges(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
     assert [r3["phid"]] not in landable
     assert [r3["phid"], r4["phid"]] not in landable
@@ -418,7 +422,7 @@ def test_calculate_landable_subgraphs_stops_multiple_repo_paths(
     )
     nodes, edges = build_stack_graph(revision_obj)
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -426,6 +430,7 @@ def test_calculate_landable_subgraphs_stops_multiple_repo_paths(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
 
     assert landable == [[r1["phid"], r2["phid"]]]
@@ -453,7 +458,7 @@ def test_calculate_landable_subgraphs_allows_distinct_repo_paths(
         phab, [r1["phid"], r2["phid"], r3["phid"], r4["phid"], r5["phid"]]
     )
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -461,6 +466,7 @@ def test_calculate_landable_subgraphs_allows_distinct_repo_paths(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
     assert len(landable) == 2
     assert [r1["phid"], r2["phid"]] in landable
@@ -488,7 +494,7 @@ def test_calculate_landable_subgraphs_different_repo_parents(
     )
 
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -496,6 +502,7 @@ def test_calculate_landable_subgraphs_different_repo_parents(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
     assert len(landable) == 2
     assert [r1["phid"]] in landable
@@ -523,7 +530,7 @@ def test_calculate_landable_subgraphs_different_repo_closed_parent(
     )
 
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -531,6 +538,7 @@ def test_calculate_landable_subgraphs_different_repo_closed_parent(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
     assert len(landable) == 1
     assert [r2["phid"], r3["phid"]] in landable
@@ -571,7 +579,7 @@ def test_calculate_landable_subgraphs_diverging_paths_merge(
     )
 
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -579,6 +587,7 @@ def test_calculate_landable_subgraphs_diverging_paths_merge(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
     assert len(landable) == 3
     assert [r1["phid"], r2["phid"], r3["phid"]] in landable
@@ -665,7 +674,7 @@ def test_calculate_landable_subgraphs_complex_graph(
     supported_repos = get_repos_for_env("test")
 
     stack = RevisionStack(set(ext_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         ext_data,
@@ -673,6 +682,7 @@ def test_calculate_landable_subgraphs_complex_graph(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
 
     assert len(landable) == 3
@@ -696,7 +706,7 @@ def test_calculate_landable_subgraphs_missing_repo(
     revision_data = request_extended_revision_data(phab, [r1["phid"]])
 
     stack = RevisionStack(set(revision_data.revisions.keys()), edges)
-    assessment, stack_state = assess_stack_state(
+    stack_state = build_stack_assessment_state(
         phab,
         supported_repos,
         revision_data,
@@ -704,6 +714,7 @@ def test_calculate_landable_subgraphs_missing_repo(
         release_management_project["phid"],
         needs_data_classification_project["phid"],
     )
+    run_landing_checks(stack_state)
     landable = stack_state.landable_stack.landable_paths()
 
     repo_unset_warning = (


### PR DESCRIPTION
The `assess_stack_state` function is doing two things at the same time.
Firstly, it is creating the `StackAssessmentState` from some arguments.
Then, it runs the checks against the state and returns a `StackAssessment`.
Split the `assess_stack_state` function into a function that returns a
`StackAssessmentState`, and have callers call `run_landing_checks`
directly. This will enable us to move the `create_state` function into
a proper fixture in a later PR.
