### PR TITLE
testing: move `uplift-target` repo to mocked repo config (Bug 1896501)

### DIFF
--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -205,14 +205,6 @@ REPO_CONFIG = {
             approval_required=True,
             milestone_tracking_flag_template="cf_status_firefox{milestone}",
         ),
-        # Approval is required for the uplift dev repo
-        "uplift-target": Repo(
-            tree="uplift-target",
-            url="http://hg.test",  # TODO: fix this? URL is probably incorrect.
-            access_group=SCM_LEVEL_1,
-            approval_required=True,
-            milestone_tracking_flag_template="cf_status_firefox{milestone}",
-        ),
     },
     "devsvcdev": {
         "test-repo": Repo(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -344,6 +344,14 @@ def mocked_repo_config(mock_repo_config):
                     is_phabricator_repo=False,
                     force_push=True,
                 ),
+                # Approval is required for the uplift dev repo
+                "uplift-target": Repo(
+                    tree="uplift-target",
+                    url="http://hg.test",
+                    access_group=SCM_LEVEL_1,
+                    approval_required=True,
+                    milestone_tracking_flag_template="cf_status_firefox{milestone}",
+                ),
             }
         }
     )

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -1576,11 +1576,15 @@ def test_check_author_planned_changes_changes_planned(phabdouble):
 
 @pytest.mark.parametrize("status", list(ReviewerStatus))
 def test_relman_approval_status(
-    status, phabdouble, release_management_project, needs_data_classification_project
+    status,
+    phabdouble,
+    mocked_repo_config,
+    release_management_project,
+    needs_data_classification_project,
 ):
     """Check only an approval from relman allows landing"""
     repo = phabdouble.repo(name="uplift-target")
-    repos = get_repos_for_env("localdev")
+    repos = get_repos_for_env("test")
     assert repos["uplift-target"].approval_required is True
 
     # Add relman as reviewer with specified status
@@ -1621,11 +1625,14 @@ def test_relman_approval_status(
 
 
 def test_relman_approval_missing(
-    phabdouble, release_management_project, needs_data_classification_project
+    phabdouble,
+    mocked_repo_config,
+    release_management_project,
+    needs_data_classification_project,
 ):
     """A repo with an approval required needs relman as reviewer"""
     repo = phabdouble.repo(name="uplift-target")
-    repos = get_repos_for_env("localdev")
+    repos = get_repos_for_env("test")
     assert repos["uplift-target"].approval_required is True
 
     revision = phabdouble.revision(repo=repo)


### PR DESCRIPTION
There is a test repo `uplift-target` used in some tests that is
added to the `local-dev` repo config. In reality this repo should
be present in the mocked out testing-only `test` repo config. Move
this test repo to the correct location and update tests with fixtures
to make the repo available.
