### PR TITLE
hg: add a snippet to consider Treestatus API failures as closed (Bug 1896696)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -70,7 +70,10 @@ class HgCommandError(HgException):
 class TreeClosed(HgException):
     """Exception when pushing failed due to a closed tree."""
 
-    SNIPPETS = (b"is CLOSED!",)
+    SNIPPETS = (
+        b"is CLOSED!",
+        b"treating as if CLOSED.",
+    )
 
 
 class TreeApprovalRequired(HgException):


### PR DESCRIPTION
Our current snippet parsing for `hg push` output looks for `is CLOSED`
to determine if a tree is closed. When the Treestatus API returns an
error, it will instead print that it is `treating as if CLOSED`. Since
we don't check for that specific string we can sometimes treat closures
as permanent failures. Add a snippet to account for this tree-closed
state.
