### PR TITLE
hooks: exclude treestatus API endpoints from maintenance mode (Bug 1896696)

### DIFF
--- a/landoapi/hooks.py
+++ b/landoapi/hooks.py
@@ -30,11 +30,14 @@ def check_maintenance() -> Optional[Response]:
         "dockerflow.version",
         "dockerflow.lbheartbeat",
     )
+    if request.endpoint in excepted_endpoints:
+        return
+
     treestatus_api_prefix = "landoapi_api_treestatus"
-    if request.endpoint in excepted_endpoints or request.endpoint.startswith(
-        treestatus_api_prefix
-    ):
-        logger.info(f"Skipping maintenance mode check for {request.endpoint} endpoints")
+    if request.endpoint.startswith(treestatus_api_prefix):
+        logger.info(
+            f"Skipping maintenance mode check for Treestatus endpoint {request.endpoint}."
+        )
         return
 
     in_maintenance = ConfigurationVariable.get(

--- a/landoapi/hooks.py
+++ b/landoapi/hooks.py
@@ -30,7 +30,10 @@ def check_maintenance() -> Optional[Response]:
         "dockerflow.version",
         "dockerflow.lbheartbeat",
     )
-    if request.endpoint in excepted_endpoints:
+    treestatus_api_prefix = "landoapi_api_treestatus"
+    if request.endpoint in excepted_endpoints or request.endpoint.startswith(
+        treestatus_api_prefix
+    ):
         return
 
     in_maintenance = ConfigurationVariable.get(

--- a/landoapi/hooks.py
+++ b/landoapi/hooks.py
@@ -34,6 +34,7 @@ def check_maintenance() -> Optional[Response]:
     if request.endpoint in excepted_endpoints or request.endpoint.startswith(
         treestatus_api_prefix
     ):
+        logger.info(f"Skipping maintenance mode check for {request.endpoint} endpoints")
         return
 
     in_maintenance = ConfigurationVariable.get(


### PR DESCRIPTION
Add an exception for the Treestatus API endpoints to the
maintenance mode hook. Unlike the dockerflow endpoints, the
Treestatus endpoints are defined with Connexion, and the
derived value of `request.endpoint` ends up being an underscore
separated represenation of the function namespace. Add a check
to exclude any endpoints that are within that namespace.
