### PR TITLE
testing: defined `create_state` as a test fixture built with Lando internals (Bug 1896501)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,10 +37,15 @@ from landoapi.projects import (
     SEC_APPROVAL_PROJECT_SLUG,
     SEC_PROJ_SLUG,
 )
-from landoapi.repos import SCM_LEVEL_1, SCM_LEVEL_3, Repo
+from landoapi.repos import SCM_LEVEL_1, SCM_LEVEL_3, Repo, get_repos_for_env
+from landoapi.stacks import (
+    RevisionStack,
+    build_stack_graph,
+    request_extended_revision_data,
+)
 from landoapi.storage import db as _db
 from landoapi.tasks import celery
-from landoapi.transplants import CODE_FREEZE_OFFSET
+from landoapi.transplants import CODE_FREEZE_OFFSET, build_stack_assessment_state
 from tests.mocks import PhabricatorDouble
 
 PATCH_NORMAL_1 = r"""
@@ -521,3 +526,34 @@ def new_treestatus_tree(db):
         return new_tree
 
     return _new_tree
+
+
+@pytest.fixture
+def create_state(
+    app,
+    phabdouble,
+    mocked_repo_config,
+    release_management_project,
+    needs_data_classification_project,
+):
+    """Create a `StackAssessmentState`."""
+
+    def create_state_handler(phab, revision, landing_assessment=None):
+        supported_repos = get_repos_for_env("test")
+        nodes, edges = build_stack_graph(revision)
+        stack_data = request_extended_revision_data(phab, list(nodes))
+        stack = RevisionStack(set(stack_data.revisions.keys()), edges)
+        relman_group_phid = release_management_project["phid"]
+        data_policy_review_phid = needs_data_classification_project["phid"]
+
+        return build_stack_assessment_state(
+            phab,
+            supported_repos,
+            stack_data,
+            stack,
+            relman_group_phid,
+            data_policy_review_phid,
+            landing_assessment=landing_assessment,
+        )
+
+    return create_state_handler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -538,7 +538,8 @@ def create_state(
 ):
     """Create a `StackAssessmentState`."""
 
-    def create_state_handler(phab, revision, landing_assessment=None):
+    def create_state_handler(revision, landing_assessment=None):
+        phab = phabdouble.get_phabricator_client()
         supported_repos = get_repos_for_env("test")
         nodes, edges = build_stack_graph(revision)
         stack_data = request_extended_revision_data(phab, list(nodes))

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -496,12 +496,11 @@ def test_get_transplant_not_authorized_to_view_revision(db, client, phabdouble):
 def test_warning_previously_landed_no_landings(db, phabdouble, create_state):
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
-    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         r, attachments={"reviewers": True, "reviewers-extra": True, "projects": True}
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
     assert warning_previously_landed(revision, diff, stack_state) is None
 
 
@@ -514,7 +513,6 @@ def test_warning_previously_landed_failed_landing(
 ):
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
-    phab = phabdouble.get_phabricator_client()
 
     create_landing_job(
         db,
@@ -527,7 +525,7 @@ def test_warning_previously_landed_failed_landing(
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_previously_landed(revision, diff, stack_state) is None
 
@@ -541,7 +539,6 @@ def test_warning_previously_landed_landed_landing(
 ):
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
-    phab = phabdouble.get_phabricator_client()
 
     create_landing_job(
         db,
@@ -554,7 +551,7 @@ def test_warning_previously_landed_landed_landing(
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_previously_landed(revision, diff, stack_state) is not None
 
@@ -564,9 +561,8 @@ def test_warning_revision_secure_project_none(phabdouble, create_state):
         phabdouble.revision(),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_revision_secure(revision, {}, stack_state) is None
 
@@ -576,9 +572,8 @@ def test_warning_revision_secure_is_secure(phabdouble, secure_project, create_st
         phabdouble.revision(projects=[secure_project]),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_revision_secure(revision, {}, stack_state) is not None
 
@@ -591,9 +586,8 @@ def test_warning_revision_secure_is_not_secure(
         phabdouble.revision(projects=[not_secure_project]),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_revision_secure(revision, {}, stack_state) is None
 
@@ -611,9 +605,8 @@ def test_warning_not_accepted_warns_on_other_status(phabdouble, status, create_s
         phabdouble.revision(status=status),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_not_accepted(revision, {}, stack_state) is not None
 
@@ -623,15 +616,13 @@ def test_warning_not_accepted_no_warning_when_accepted(phabdouble, create_state)
         phabdouble.revision(status=PhabricatorRevisionStatus.ACCEPTED),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_not_accepted(revision, {}, stack_state) is None
 
 
 def test_warning_reviews_not_current_warns_on_unreviewed_diff(phabdouble, create_state):
-    phab = phabdouble.get_phabricator_client()
     d_reviewed = phabdouble.diff()
     r = phabdouble.revision(diff=d_reviewed)
     phabdouble.reviewer(
@@ -646,7 +637,7 @@ def test_warning_reviews_not_current_warns_on_unreviewed_diff(phabdouble, create
     )
     diff = phabdouble.api_object_for(d_new, attachments={"commits": True})
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_reviews_not_current(revision, diff, stack_state) is not None
 
@@ -654,7 +645,6 @@ def test_warning_reviews_not_current_warns_on_unreviewed_diff(phabdouble, create
 def test_warning_reviews_not_current_warns_on_unreviewed_revision(
     phabdouble, create_state
 ):
-    phab = phabdouble.get_phabricator_client()
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
     # Don't create any reviewers.
@@ -664,7 +654,7 @@ def test_warning_reviews_not_current_warns_on_unreviewed_revision(
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_reviews_not_current(revision, diff, stack_state) is not None
 
@@ -672,7 +662,6 @@ def test_warning_reviews_not_current_warns_on_unreviewed_revision(
 def test_warning_reviews_not_current_no_warning_on_accepted_diff(
     phabdouble, create_state
 ):
-    phab = phabdouble.get_phabricator_client()
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
     phabdouble.reviewer(
@@ -687,7 +676,7 @@ def test_warning_reviews_not_current_no_warning_on_accepted_diff(
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_reviews_not_current(revision, diff, stack_state) is None
 
@@ -1340,7 +1329,6 @@ def test_integrated_transplant_sec_approval_group_is_excluded_from_reviewers_lis
 
 
 def test_warning_wip_commit_message(phabdouble, create_state):
-    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         phabdouble.revision(
             title="WIP: Bug 123: test something r?reviewer",
@@ -1349,7 +1337,7 @@ def test_warning_wip_commit_message(phabdouble, create_state):
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
 
     assert warning_wip_commit_message(revision, {}, stack_state) is not None
 
@@ -1520,12 +1508,11 @@ def test_unresolved_comment_stack(
 def test_check_author_planned_changes_changes_not_planned(
     phabdouble, status, create_state
 ):
-    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         phabdouble.revision(status=status),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
     assert (
         blocker_author_planned_changes(
             revision=revision, diff={}, stack_state=stack_state
@@ -1535,12 +1522,11 @@ def test_check_author_planned_changes_changes_not_planned(
 
 
 def test_check_author_planned_changes_changes_planned(phabdouble, create_state):
-    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         phabdouble.revision(status=PhabricatorRevisionStatus.CHANGES_PLANNED),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    stack_state = create_state(phab, revision)
+    stack_state = create_state(revision)
     assert (
         blocker_author_planned_changes(
             revision=revision, diff={}, stack_state=stack_state
@@ -1559,8 +1545,6 @@ def test_relman_approval_status(
     needs_data_classification_project,
 ):
     """Check only an approval from relman allows landing"""
-    phab = phabdouble.get_phabricator_client()
-
     repo = phabdouble.repo(name="uplift-target")
     repos = get_repos_for_env("test")
     assert repos["uplift-target"].approval_required is True
@@ -1582,7 +1566,7 @@ def test_relman_approval_status(
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    stack_state = create_state(phab, phab_revision)
+    stack_state = create_state(phab_revision)
     output = blocker_uplift_approval(
         revision=phab_revision, diff={}, stack_state=stack_state
     )
@@ -1603,8 +1587,6 @@ def test_relman_approval_missing(
     needs_data_classification_project,
 ):
     """A repo with an approval required needs relman as reviewer"""
-    phab = phabdouble.get_phabricator_client()
-
     repo = phabdouble.repo(name="uplift-target")
     repos = get_repos_for_env("test")
     assert repos["uplift-target"].approval_required is True
@@ -1615,7 +1597,7 @@ def test_relman_approval_missing(
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    stack_state = create_state(phab, phab_revision)
+    stack_state = create_state(phab_revision)
     assert blocker_uplift_approval(
         revision=phab_revision, diff={}, stack_state=stack_state
     ) == (
@@ -1628,8 +1610,6 @@ def test_relman_approval_missing(
 def test_revision_has_data_classification_tag(
     phabdouble, create_state, needs_data_classification_project
 ):
-    phab = phabdouble.get_phabricator_client()
-
     repo = phabdouble.repo()
     revision = phabdouble.revision(
         repo=repo, projects=[needs_data_classification_project]
@@ -1639,7 +1619,7 @@ def test_revision_has_data_classification_tag(
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    stack_state = create_state(phab, phab_revision)
+    stack_state = create_state(phab_revision)
 
     assert blocker_revision_data_classification(
         revision=phab_revision, diff={}, stack_state=stack_state
@@ -1653,7 +1633,7 @@ def test_revision_has_data_classification_tag(
         revision,
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    stack_state = create_state(phab, phab_revision)
+    stack_state = create_state(phab_revision)
     assert (
         blocker_revision_data_classification(
             revision=phab_revision, diff={}, stack_state=stack_state
@@ -1681,7 +1661,6 @@ index 0000000..55faaf5
 
 
 def test_blocker_prevent_symlinks(phabdouble, create_state):
-    phab = phabdouble.get_phabricator_client()
     repo = phabdouble.repo()
 
     # Create a revision/diff pair without a symlink.
@@ -1700,7 +1679,7 @@ def test_blocker_prevent_symlinks(phabdouble, create_state):
     )
     diff_symlink = phabdouble.diff(rawdiff=SYMLINK_DIFF, revision=revision_symlink)
 
-    stack_state = create_state(phab, phab_revision_symlink)
+    stack_state = create_state(phab_revision_symlink)
 
     assert (
         blocker_prevent_symlinks(

--- a/tests/test_transplants.py
+++ b/tests/test_transplants.py
@@ -3,12 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from datetime import datetime, timezone
-from typing import Optional
 from unittest.mock import MagicMock
 
 import pytest
 
-from landoapi.auth import A0User
 from landoapi.hg import HgRepo
 from landoapi.mocks.canned_responses.auth0 import CANNED_USERINFO
 from landoapi.models.landing_job import (
@@ -19,24 +17,18 @@ from landoapi.models.landing_job import (
 from landoapi.models.revisions import Revision
 from landoapi.models.transplant import Transplant
 from landoapi.phabricator import (
-    PhabricatorClient,
     PhabricatorRevisionStatus,
     ReviewerStatus,
 )
 from landoapi.repos import DONTBUILD, SCM_CONDUIT, SCM_LEVEL_3, Repo, get_repos_for_env
-from landoapi.reviews import get_collated_reviewers
-from landoapi.stacks import RevisionData, RevisionStack, request_extended_revision_data
 from landoapi.tasks import admin_remove_phab_project
 from landoapi.transplants import (
-    LandingAssessmentState,
     RevisionWarning,
     StackAssessment,
-    StackAssessmentState,
     blocker_author_planned_changes,
     blocker_prevent_symlinks,
     blocker_revision_data_classification,
     blocker_uplift_approval,
-    get_parsed_diffs,
     warning_not_accepted,
     warning_previously_landed,
     warning_reviews_not_current,
@@ -112,46 +104,6 @@ def _create_landing_job_with_no_linked_revisions(
     job.revision_order = [str(revision.revision_id) for revision in revisions]
     db.session.commit()
     return job
-
-
-def create_landing_state(**kwargs):
-    state = {
-        "auth0_user": A0User("", {}),
-        "landing_path_by_phid": [],
-        "to_land": [],
-        "landing_repo": None,
-    }
-
-    state.update(kwargs)
-
-    return LandingAssessmentState(**state)
-
-
-def create_state(landing_state: Optional[LandingAssessmentState] = None, **kwargs):
-    landing_state = landing_state or create_landing_state()
-
-    state = {
-        "phab": PhabricatorClient("testing123", "testing123"),
-        "stack_data": RevisionData({}, {}, {}),
-        "stack": RevisionStack([], []),
-        "parsed_diffs": {},
-        "statuses": {},
-        "landable_stack": RevisionStack([], []),
-        "landable_repos": {},
-        "reviewers": {},
-        "users": {},
-        "projects": {},
-        "supported_repos": {},
-        "data_policy_review_phid": "",
-        "relman_group_phid": "",
-        "secure_project_phid": "",
-        "testing_tag_project_phids": [],
-        "testing_policy_phid": "",
-        "landing_assessment": landing_state,
-    }
-    state.update(kwargs)
-
-    return StackAssessmentState(**state)
 
 
 def test_dryrun_no_warnings_or_blockers(
@@ -541,14 +493,15 @@ def test_get_transplant_not_authorized_to_view_revision(db, client, phabdouble):
     assert response.status_code == 404
 
 
-def test_warning_previously_landed_no_landings(db, phabdouble):
+def test_warning_previously_landed_no_landings(db, phabdouble, create_state):
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
+    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         r, attachments={"reviewers": True, "reviewers-extra": True, "projects": True}
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
     assert warning_previously_landed(revision, diff, stack_state) is None
 
 
@@ -556,9 +509,12 @@ def test_warning_previously_landed_no_landings(db, phabdouble):
     "create_landing_job",
     (_create_landing_job, _create_landing_job_with_no_linked_revisions),
 )
-def test_warning_previously_landed_failed_landing(db, phabdouble, create_landing_job):
+def test_warning_previously_landed_failed_landing(
+    db, phabdouble, create_landing_job, create_state
+):
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
+    phab = phabdouble.get_phabricator_client()
 
     create_landing_job(
         db,
@@ -571,7 +527,7 @@ def test_warning_previously_landed_failed_landing(db, phabdouble, create_landing
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
 
     assert warning_previously_landed(revision, diff, stack_state) is None
 
@@ -580,9 +536,12 @@ def test_warning_previously_landed_failed_landing(db, phabdouble, create_landing
     "create_landing_job",
     (_create_landing_job, _create_landing_job_with_no_linked_revisions),
 )
-def test_warning_previously_landed_landed_landing(db, phabdouble, create_landing_job):
+def test_warning_previously_landed_landed_landing(
+    db, phabdouble, create_landing_job, create_state
+):
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
+    phab = phabdouble.get_phabricator_client()
 
     create_landing_job(
         db,
@@ -595,41 +554,46 @@ def test_warning_previously_landed_landed_landing(db, phabdouble, create_landing
     )
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
 
     assert warning_previously_landed(revision, diff, stack_state) is not None
 
 
-def test_warning_revision_secure_project_none(phabdouble):
+def test_warning_revision_secure_project_none(phabdouble, create_state):
     revision = phabdouble.api_object_for(
         phabdouble.revision(),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
+    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(secure_project_phid=None)
+    stack_state = create_state(phab, revision)
 
     assert warning_revision_secure(revision, {}, stack_state) is None
 
 
-def test_warning_revision_secure_is_secure(phabdouble, secure_project):
+def test_warning_revision_secure_is_secure(phabdouble, secure_project, create_state):
     revision = phabdouble.api_object_for(
         phabdouble.revision(projects=[secure_project]),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
+    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(secure_project_phid=secure_project["phid"])
+    stack_state = create_state(phab, revision)
 
     assert warning_revision_secure(revision, {}, stack_state) is not None
 
 
-def test_warning_revision_secure_is_not_secure(phabdouble, secure_project):
+def test_warning_revision_secure_is_not_secure(
+    phabdouble, secure_project, create_state
+):
     not_secure_project = phabdouble.project("not_secure_project")
     revision = phabdouble.api_object_for(
         phabdouble.revision(projects=[not_secure_project]),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
+    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state(secure_project_phid=secure_project["phid"])
+    stack_state = create_state(phab, revision)
 
     assert warning_revision_secure(revision, {}, stack_state) is None
 
@@ -642,29 +606,32 @@ def test_warning_revision_secure_is_not_secure(phabdouble, secure_project):
         if s is not PhabricatorRevisionStatus.ACCEPTED
     ],
 )
-def test_warning_not_accepted_warns_on_other_status(phabdouble, status):
+def test_warning_not_accepted_warns_on_other_status(phabdouble, status, create_state):
     revision = phabdouble.api_object_for(
         phabdouble.revision(status=status),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
+    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
 
     assert warning_not_accepted(revision, {}, stack_state) is not None
 
 
-def test_warning_not_accepted_no_warning_when_accepted(phabdouble):
+def test_warning_not_accepted_no_warning_when_accepted(phabdouble, create_state):
     revision = phabdouble.api_object_for(
         phabdouble.revision(status=PhabricatorRevisionStatus.ACCEPTED),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
+    phab = phabdouble.get_phabricator_client()
 
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
 
     assert warning_not_accepted(revision, {}, stack_state) is None
 
 
-def test_warning_reviews_not_current_warns_on_unreviewed_diff(phabdouble):
+def test_warning_reviews_not_current_warns_on_unreviewed_diff(phabdouble, create_state):
+    phab = phabdouble.get_phabricator_client()
     d_reviewed = phabdouble.diff()
     r = phabdouble.revision(diff=d_reviewed)
     phabdouble.reviewer(
@@ -677,15 +644,17 @@ def test_warning_reviews_not_current_warns_on_unreviewed_diff(phabdouble):
     revision = phabdouble.api_object_for(
         r, attachments={"reviewers": True, "reviewers-extra": True, "projects": True}
     )
-    reviewers = get_collated_reviewers(revision)
     diff = phabdouble.api_object_for(d_new, attachments={"commits": True})
 
-    stack_state = create_state(reviewers={revision["phid"]: reviewers})
+    stack_state = create_state(phab, revision)
 
     assert warning_reviews_not_current(revision, diff, stack_state) is not None
 
 
-def test_warning_reviews_not_current_warns_on_unreviewed_revision(phabdouble):
+def test_warning_reviews_not_current_warns_on_unreviewed_revision(
+    phabdouble, create_state
+):
+    phab = phabdouble.get_phabricator_client()
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
     # Don't create any reviewers.
@@ -693,15 +662,17 @@ def test_warning_reviews_not_current_warns_on_unreviewed_revision(phabdouble):
     revision = phabdouble.api_object_for(
         r, attachments={"reviewers": True, "reviewers-extra": True, "projects": True}
     )
-    reviewers = get_collated_reviewers(revision)
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state(reviewers={revision["phid"]: reviewers})
+    stack_state = create_state(phab, revision)
 
     assert warning_reviews_not_current(revision, diff, stack_state) is not None
 
 
-def test_warning_reviews_not_current_no_warning_on_accepted_diff(phabdouble):
+def test_warning_reviews_not_current_no_warning_on_accepted_diff(
+    phabdouble, create_state
+):
+    phab = phabdouble.get_phabricator_client()
     d = phabdouble.diff()
     r = phabdouble.revision(diff=d)
     phabdouble.reviewer(
@@ -714,10 +685,9 @@ def test_warning_reviews_not_current_no_warning_on_accepted_diff(phabdouble):
     revision = phabdouble.api_object_for(
         r, attachments={"reviewers": True, "reviewers-extra": True, "projects": True}
     )
-    reviewers = get_collated_reviewers(revision)
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
-    stack_state = create_state(reviewers={revision["phid"]: reviewers})
+    stack_state = create_state(phab, revision)
 
     assert warning_reviews_not_current(revision, diff, stack_state) is None
 
@@ -1369,7 +1339,8 @@ def test_integrated_transplant_sec_approval_group_is_excluded_from_reviewers_lis
     assert sec_approval_project["name"] not in transplanted_patch.patch_string
 
 
-def test_warning_wip_commit_message(phabdouble):
+def test_warning_wip_commit_message(phabdouble, create_state):
+    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         phabdouble.revision(
             title="WIP: Bug 123: test something r?reviewer",
@@ -1378,7 +1349,7 @@ def test_warning_wip_commit_message(phabdouble):
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
 
     assert warning_wip_commit_message(revision, {}, stack_state) is not None
 
@@ -1546,12 +1517,15 @@ def test_unresolved_comment_stack(
         if s is not PhabricatorRevisionStatus.CHANGES_PLANNED
     ],
 )
-def test_check_author_planned_changes_changes_not_planned(phabdouble, status):
+def test_check_author_planned_changes_changes_not_planned(
+    phabdouble, status, create_state
+):
+    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         phabdouble.revision(status=status),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
     assert (
         blocker_author_planned_changes(
             revision=revision, diff={}, stack_state=stack_state
@@ -1560,12 +1534,13 @@ def test_check_author_planned_changes_changes_not_planned(phabdouble, status):
     )
 
 
-def test_check_author_planned_changes_changes_planned(phabdouble):
+def test_check_author_planned_changes_changes_planned(phabdouble, create_state):
+    phab = phabdouble.get_phabricator_client()
     revision = phabdouble.api_object_for(
         phabdouble.revision(status=PhabricatorRevisionStatus.CHANGES_PLANNED),
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
-    stack_state = create_state()
+    stack_state = create_state(phab, revision)
     assert (
         blocker_author_planned_changes(
             revision=revision, diff={}, stack_state=stack_state
@@ -1579,10 +1554,13 @@ def test_relman_approval_status(
     status,
     phabdouble,
     mocked_repo_config,
+    create_state,
     release_management_project,
     needs_data_classification_project,
 ):
     """Check only an approval from relman allows landing"""
+    phab = phabdouble.get_phabricator_client()
+
     repo = phabdouble.repo(name="uplift-target")
     repos = get_repos_for_env("test")
     assert repos["uplift-target"].approval_required is True
@@ -1604,14 +1582,7 @@ def test_relman_approval_status(
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    phab_client = phabdouble.get_phabricator_client()
-    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
-
-    stack_state = create_state(
-        relman_group_phid=release_management_project["phid"],
-        supported_repos=repos,
-        stack_data=stack_data,
-    )
+    stack_state = create_state(phab, phab_revision)
     output = blocker_uplift_approval(
         revision=phab_revision, diff={}, stack_state=stack_state
     )
@@ -1627,10 +1598,13 @@ def test_relman_approval_status(
 def test_relman_approval_missing(
     phabdouble,
     mocked_repo_config,
+    create_state,
     release_management_project,
     needs_data_classification_project,
 ):
     """A repo with an approval required needs relman as reviewer"""
+    phab = phabdouble.get_phabricator_client()
+
     repo = phabdouble.repo(name="uplift-target")
     repos = get_repos_for_env("test")
     assert repos["uplift-target"].approval_required is True
@@ -1641,14 +1615,7 @@ def test_relman_approval_missing(
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    phab_client = phabdouble.get_phabricator_client()
-    stack_data = request_extended_revision_data(phab_client, [revision["phid"]])
-
-    stack_state = create_state(
-        relman_group_phid=release_management_project["phid"],
-        supported_repos=repos,
-        stack_data=stack_data,
-    )
+    stack_state = create_state(phab, phab_revision)
     assert blocker_uplift_approval(
         revision=phab_revision, diff={}, stack_state=stack_state
     ) == (
@@ -1659,8 +1626,10 @@ def test_relman_approval_missing(
 
 
 def test_revision_has_data_classification_tag(
-    phabdouble, needs_data_classification_project
+    phabdouble, create_state, needs_data_classification_project
 ):
+    phab = phabdouble.get_phabricator_client()
+
     repo = phabdouble.repo()
     revision = phabdouble.revision(
         repo=repo, projects=[needs_data_classification_project]
@@ -1670,9 +1639,7 @@ def test_revision_has_data_classification_tag(
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
 
-    stack_state = create_state(
-        data_policy_review_phid=needs_data_classification_project["phid"]
-    )
+    stack_state = create_state(phab, phab_revision)
 
     assert blocker_revision_data_classification(
         revision=phab_revision, diff={}, stack_state=stack_state
@@ -1686,6 +1653,7 @@ def test_revision_has_data_classification_tag(
         revision,
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
+    stack_state = create_state(phab, phab_revision)
     assert (
         blocker_revision_data_classification(
             revision=phab_revision, diff={}, stack_state=stack_state
@@ -1712,7 +1680,8 @@ index 0000000..55faaf5
 """.lstrip()
 
 
-def test_blocker_prevent_symlinks(phabdouble):
+def test_blocker_prevent_symlinks(phabdouble, create_state):
+    phab = phabdouble.get_phabricator_client()
     repo = phabdouble.repo()
 
     # Create a revision/diff pair without a symlink.
@@ -1724,23 +1693,14 @@ def test_blocker_prevent_symlinks(phabdouble):
     diff_normal = phabdouble.diff(revision=revision)
 
     # Create a revision/diff pair with a symlink.
-    revision_symlink = phabdouble.revision(repo=repo)
+    revision_symlink = phabdouble.revision(repo=repo, depends_on=[revision])
     phab_revision_symlink = phabdouble.api_object_for(
         revision_symlink,
         attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
     )
     diff_symlink = phabdouble.diff(rawdiff=SYMLINK_DIFF, revision=revision_symlink)
 
-    # Collect extended revision data for both revisions.
-    phab_client = phabdouble.get_phabricator_client()
-    stack_data = request_extended_revision_data(
-        phab_client, [revision["phid"], revision_symlink["phid"]]
-    )
-
-    # Parse diffs into `rs_parsepatch` format.
-    parsed_diffs = get_parsed_diffs(phab_client, stack_data)
-
-    stack_state = create_state(stack_data=stack_data, parsed_diffs=parsed_diffs)
+    stack_state = create_state(phab, phab_revision_symlink)
 
     assert (
         blocker_prevent_symlinks(


### PR DESCRIPTION
Redefine `create_state` as a pytest fixture built with existing
fixtures and proper Lando internals. This brings the state used
in the tests post-refactor more in line with our existing test
infrastructure.
