### PR TITLE
hooks: add a diff inspection API for landings and try pushes (Bug 1899584)

### DIFF
--- a/landoapi/api/try_push.py
+++ b/landoapi/api/try_push.py
@@ -62,7 +62,7 @@ def build_revision_from_patch_helper(helper: PatchHelper, repo: Repo) -> Revisio
 
     # Check diff for errors.
     parsed_diff = rs_parsepatch.get_diffs(raw_diff)
-    errors = DiffAssessor(parsed_diff).run_diff_checks(repo)
+    errors = DiffAssessor(parsed_diff=parsed_diff, repo=repo).run_diff_checks()
     if errors:
         raise ValueError(f"Patch failed checks: {' '.join(errors)}")
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -405,8 +405,9 @@ class DiffAssessor:
     """
 
     parsed_diff: list[dict]
+    repo: Optional[Repo] = None
 
-    def check_prevent_symlinks(self, **kwargs) -> Optional[str]:
+    def check_prevent_symlinks(self) -> Optional[str]:
         """Check for symlinks introduced in the diff."""
         symlinked_files = []
         for parsed in self.parsed_diff:
@@ -422,22 +423,20 @@ class DiffAssessor:
             wrapped_filenames = (f"`{filename}`" for filename in symlinked_files)
             return f"Revision introduces symlinks in the files {','.join(wrapped_filenames)}."
 
-    def check_try_task_config(
-        self, repo: Optional[Repo] = None, **kwargs
-    ) -> Optional[str]:
+    def check_try_task_config(self) -> Optional[str]:
         """Check for `try_task_config.json` introduced in the diff."""
-        if repo and repo.tree == "try":
+        if self.repo and self.repo.tree == "try":
             return
 
         for parsed in self.parsed_diff:
             if parsed["filename"] == "try_task_config.json":
                 return "Revision introduces the `try_task_config.json` file."
 
-    def run_diff_checks(self, repo: Repo) -> list[str]:
+    def run_diff_checks(self) -> list[str]:
         """Execute the set of checks on the diffs."""
         issues = []
         for check in (self.check_prevent_symlinks, self.check_try_task_config):
-            if issue := check(repo=repo):
+            if issue := check():
                 issues.append(issue)
 
         return issues

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -8,6 +8,7 @@ import email
 import io
 import math
 import re
+from dataclasses import dataclass
 from datetime import datetime
 from email.policy import (
     default as default_email_policy,
@@ -18,6 +19,8 @@ from email.utils import (
 from typing import (
     Optional,
 )
+
+from landoapi.repos import Repo
 
 HG_HEADER_NAMES = (
     "User",
@@ -388,3 +391,53 @@ class GitPatchHelper(PatchHelper):
             raise ValueError("Patch does not have a `Date:` header.")
 
         return get_timestamp_from_git_date_header(date)
+
+
+# Decimal notation for the `symlink` file mode.
+SYMLINK_MODE = 40960
+
+
+@dataclass
+class DiffAssessor:
+    """Assess diffs for landing issues.
+
+    Diffs should be passed in `rs-parsepatch` format.
+    """
+
+    parsed_diff: list[dict]
+
+    def check_prevent_symlinks(self, **kwargs) -> Optional[str]:
+        """Check for symlinks introduced in the diff."""
+        symlinked_files = []
+        for parsed in self.parsed_diff:
+            modes = parsed["modes"]
+
+            # Check the file mode on each file and ensure the file is not a symlink.
+            # `rs_parsepatch` has a `new` and `old` mode key, we are interested in
+            # only the newly introduced modes.
+            if "new" in modes and modes["new"] == SYMLINK_MODE:
+                symlinked_files.append(parsed["filename"])
+
+        if symlinked_files:
+            wrapped_filenames = (f"`{filename}`" for filename in symlinked_files)
+            return f"Revision introduces symlinks in the files {','.join(wrapped_filenames)}."
+
+    def check_try_task_config(
+        self, repo: Optional[Repo] = None, **kwargs
+    ) -> Optional[str]:
+        """Check for `try_task_config.json` introduced in the diff."""
+        if repo and repo.tree == "try":
+            return
+
+        for parsed in self.parsed_diff:
+            if parsed["filename"] == "try_task_config.json":
+                return "Revision introduces the `try_task_config.json` file."
+
+    def run_diff_checks(self, repo: Repo) -> list[str]:
+        """Execute the set of checks on the diffs."""
+        issues = []
+        for check in (self.check_prevent_symlinks, self.check_try_task_config):
+            if issue := check(repo=repo):
+                issues.append(issue)
+
+        return issues

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -853,7 +853,7 @@ def blocker_prevent_symlinks(
     diff_id = PhabricatorClient.expect(diff, "id")
     parsed_diff = stack_state.parsed_diffs[diff_id]
 
-    return DiffAssessor(parsed_diff).check_prevent_symlinks()
+    return DiffAssessor(parsed_diff=parsed_diff).check_prevent_symlinks()
 
 
 def blocker_try_task_config(
@@ -865,7 +865,9 @@ def blocker_try_task_config(
 
     local_repo = stack_state.get_repo_for_revision(revision)
 
-    return DiffAssessor(parsed_diff).check_try_task_config(repo=local_repo)
+    return DiffAssessor(
+        parsed_diff=parsed_diff, repo=local_repo
+    ).check_try_task_config()
 
 
 STACK_BLOCKER_CHECKS = [

--- a/tests/test_try.py
+++ b/tests/test_try.py
@@ -162,6 +162,132 @@ def test_try_api_patch_format_mismatch(
     ), "Response should indicate the patch could not be decoded."
 
 
+SYMLINK_PATCH = rb"""
+From 751ad4b6ba7299815974d200e34832a007a4b4c0 Mon Sep 17 00:00:00 2001
+From: Connor Sheehan <cosheehan@mozilla.com>
+Date: Wed, 8 May 2024 13:32:11 -0400
+Subject: [PATCH] add regular file and symlink file
+
+---
+ blahfile_real    | 1 +
+ blahfile_symlink | 1 +
+ 2 files changed, 2 insertions(+)
+ create mode 100644 blahfile_real
+ create mode 120000 blahfile_symlink
+
+diff --git a/blahfile_real b/blahfile_real
+new file mode 100644
+index 0000000..907b308
+--- /dev/null
++++ b/blahfile_real
+@@ -0,0 +1 @@
++blah
+diff --git a/blahfile_symlink b/blahfile_symlink
+new file mode 120000
+index 0000000..55faaf5
+--- /dev/null
++++ b/blahfile_symlink
+@@ -0,0 +1 @@
++/home/sheehan/blahfile
+\ No newline at end of file
+--
+2.45.1
+
+""".lstrip()
+
+TRY_TASK_CONFIG_PATCH = rb"""
+From 888efb4b038a85a8788f25dbb69ff03f0fd58dce Mon Sep 17 00:00:00 2001
+From: Connor Sheehan <cosheehan@mozilla.com>
+Date: Wed, 8 May 2024 14:47:10 -0400
+Subject: [PATCH] add try task config
+
+---
+ blah.json            | 1 +
+ try_task_config.json | 1 +
+ 2 files changed, 2 insertions(+)
+ create mode 100644 blah.json
+ create mode 100644 try_task_config.json
+
+diff --git a/blah.json b/blah.json
+new file mode 100644
+index 0000000..663cbc2
+--- /dev/null
++++ b/blah.json
+@@ -0,0 +1 @@
++{"123":"456"}
+diff --git a/try_task_config.json b/try_task_config.json
+new file mode 100644
+index 0000000..e44d36d
+--- /dev/null
++++ b/try_task_config.json
+@@ -0,0 +1 @@
++{"env": {"TRY_SELECTOR": "fuzzy"}, "version": 1, "tasks": ["source-test-cram-tryselect"]}
+--
+2.45.1
+
+""".lstrip()
+
+
+def test_symlink_diff_inspect(
+    app,
+    db,
+    hg_server,
+    hg_clone,
+    new_treestatus_tree,
+    client,
+    auth0_mock,
+    mocked_repo_config,
+):
+    try_push_json = {
+        # The only node in the test repo.
+        "base_commit": "0da79df0ffff88e0ad6fa3e27508bcf5b2f2cec4",
+        "patch_format": "git-format-patch",
+        "patches": [
+            base64.b64encode(SYMLINK_PATCH).decode("ascii"),
+        ],
+    }
+
+    response = client.post(
+        "/try/patches", json=try_push_json, headers=auth0_mock.mock_headers
+    )
+    assert (
+        response.status_code == 400
+    ), "Try push which fails diff checks should return 400."
+
+    assert response.json["title"] == "Improper patch format."
+    assert response.json["detail"] == (
+        "Patch does not match expected format `git-format-patch`: "
+        "Patch failed checks: Revision introduces symlinks in the files `blahfile_symlink`."
+    ), "Details message should indicate an introduced symlink."
+
+
+def test_try_task_config_diff_inspect(
+    app,
+    db,
+    hg_server,
+    hg_clone,
+    new_treestatus_tree,
+    client,
+    auth0_mock,
+    mocked_repo_config,
+):
+    try_push_json = {
+        # The only node in the test repo.
+        "base_commit": "0da79df0ffff88e0ad6fa3e27508bcf5b2f2cec4",
+        "patch_format": "git-format-patch",
+        "patches": [
+            base64.b64encode(TRY_TASK_CONFIG_PATCH).decode("ascii"),
+        ],
+    }
+
+    response = client.post(
+        "/try/patches", json=try_push_json, headers=auth0_mock.mock_headers
+    )
+    assert (
+        response.status_code == 201
+    ), "Try push with a `try_task_config.json` should be accepted."
+
+
 def test_try_api_unknown_patch_format(
     app,
     db,


### PR DESCRIPTION
Add a `DiffAssessor` class as an internal API for running
diff-based checks. Move existing diff-inspecting checks
into the API and update landing checks to use them. Add
a `run_diff_checks` method which runs each check and
returns a list of string errors for display on failure.
Hook the `run_diff_checks` API into the try push revision
building function, so the currently ported checks are
run on try pushes. Add integration tests to show that
pushes are accepted/rejected as appropriate based on
these diff checks.

Since some checks will require inspection of the landing
repo to determine if the check is valid, we add a
`get_repo_for_revision` method that returns the repo for
a revision based on the passed `revision` Phabricator API
object. The logic is derived from the uplift blocking
check where it is updated, and is re-used in the
`try_task_config.json` blocker test.

Also, the type hint for `parsed_diffs` was noted to be incorrect,
and has been fixed as a ridealong in this PR.
