### PR TITLE
hgexports: port NSS/NSRP and WPTSync bot update prevention hooks as Lando checks (Bug 1903456)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -408,6 +408,11 @@ WPT_SYNC_ALLOWED_PATHS_RE = re.compile(
 )
 
 
+def wrap_filenames(filenames: list[str]) -> str:
+    """Convert a list of filenames to a string with names wrapped in backticks."""
+    return ",".join(f"`{filename}`" for filename in filenames)
+
+
 @dataclass
 class DiffAssessor:
     """Assess diffs for landing issues.
@@ -433,8 +438,7 @@ class DiffAssessor:
                 symlinked_files.append(parsed["filename"])
 
         if symlinked_files:
-            wrapped_filenames = (f"`{filename}`" for filename in symlinked_files)
-            return f"Revision introduces symlinks in the files {','.join(wrapped_filenames)}."
+            return f"Revision introduces symlinks in the files {wrap_filenames(symlinked_files)}."
 
     def check_try_task_config(self) -> Optional[str]:
         """Check for `try_task_config.json` introduced in the diff."""
@@ -522,10 +526,9 @@ class DiffAssessor:
                 disallowed_files.append(filename)
 
         if disallowed_files:
-            wrapped_filenames = (f"`{filename}`" for filename in disallowed_files)
             return (
-                f"Revision allows WPTSync bot to make changes to disallowed files "
-                f"{','.join(wrapped_filenames)}."
+                "Revision allows WPTSync bot to make changes to disallowed files "
+                f"{wrap_filenames(disallowed_files)}."
             )
 
     def build_prevent_nspr_nss_error_message(
@@ -542,16 +545,12 @@ class DiffAssessor:
         if nss_disallowed_changes:
             return_error_message.append("vendored NSS directories:")
 
-            wrapped_filenames = (f"`{filename}`" for filename in nss_disallowed_changes)
-            return_error_message.append(",".join(wrapped_filenames))
+            return_error_message.append(wrap_filenames(nss_disallowed_changes))
 
         if nspr_disallowed_changes:
             return_error_message.append("vendored NSPR directories:")
 
-            wrapped_filenames = (
-                f"`{filename}`" for filename in nspr_disallowed_changes
-            )
-            return_error_message.append(",".join(wrapped_filenames))
+            return_error_message.append(wrap_filenames(nspr_disallowed_changes))
 
         return " ".join(return_error_message) + "."
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -524,7 +524,7 @@ class DiffAssessor:
 
         if disallowed_files:
             return (
-                "Revision allows WPTSync bot to make changes to disallowed files "
+                "Revision has WPTSync bot making changes to disallowed files "
                 f"{wrap_filenames(disallowed_files)}."
             )
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -552,7 +552,7 @@ class DiffAssessor:
 
             return_error_message.append(wrap_filenames(nspr_disallowed_changes))
 
-        return " ".join(return_error_message) + "."
+        return f"{' '.join(return_error_message)}."
 
     def check_prevent_nspr_nss(self) -> Optional[str]:
         """Prevent changes to vendored NSPR directories."""

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -510,10 +510,7 @@ class DiffAssessor:
         if self.author != "wptsync@mozilla.com":
             return
 
-        if not self.repo:
-            return
-
-        if self.repo.tree == "try":
+        if not self.repo or self.repo.tree == "try":
             return
 
         if self.repo.tree != "mozilla-central":

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -676,9 +676,8 @@ def test_check_wpt_sync_invalid_paths(mocked_repo_config):
         repo=valid_repo,
     )
     assert diff_assessor.check_wpt_sync() == (
-        "Revision allows WPTSync bot to make changes to disallowed "
-        "files `somefile.txt`."
-    ), "Check should fail if WPTSync bot pushes to disallowed repo."
+        "Revision has WPTSync bot making changes to disallowed " "files `somefile.txt`."
+    ), "Check should fail if WPTSync bot pushes disallowed files."
 
 
 def test_check_wpt_sync_valid_paths(mocked_repo_config):


### PR DESCRIPTION
Add a `check_wpt_sync` check to the `DiffAssessor` class which
is a port of the `prevent_wptsync_changes.py` hook in v-c-t.
The hook uses a regex to assert that the WPTSync bot user cannot
make changes to files outside of a specific directory in the main
tree. The bot is allowed to push any changes to `try`, but is
otherwise only allowed to make changes to files matching the regex.

Implement the `prevent_nspr_nss_changes.py` hook from v-c-t as a
check on the `DiffAssessor` API within Lando. The hook checks for
file changes under given directories in the tree and prevents updates
without a specific keyword in the commit message.
