### PR TITLE
hgexports: add a check to prevent introducing Git submodules (Bug 1903462)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -584,6 +584,12 @@ class DiffAssessor:
             nss_disallowed_changes, nspr_disallowed_changes
         )
 
+    def check_prevent_submodules(self) -> Optional[str]:
+        """Prevent introduction of Git submodules into the repository."""
+        for parsed in self.parsed_diff:
+            if parsed["filename"] == ".gitmodules":
+                return "Revision introduces a Git submodule into the repository."
+
     def run_diff_checks(self) -> list[str]:
         """Execute the set of checks on the diffs."""
         issues = []
@@ -593,6 +599,7 @@ class DiffAssessor:
             self.check_commit_message,
             self.check_wpt_sync,
             self.check_prevent_nspr_nss,
+            self.check_prevent_submodules,
         ):
             if issue := check():
                 issues.append(issue)

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -851,3 +851,24 @@ def test_check_prevent_nspr_nss_combined(mocked_repo_config):
     assert (
         diff_assessor.check_prevent_nspr_nss() is None
     ), "Check should allow changes to NSPR with proper commit message."
+
+
+def test_check_prevent_submodules():
+    parsed_diff = rs_parsepatch.get_diffs(
+        GIT_DIFF_FILENAME_TEMPLATE.format(filename="security/nss/testfile.txt")
+    )
+    diff_assessor = DiffAssessor(parsed_diff=parsed_diff)
+
+    assert (
+        diff_assessor.check_prevent_submodules() is None
+    ), "Check should pass when no submodules are introduced."
+
+    parsed_diff = rs_parsepatch.get_diffs(
+        GIT_DIFF_FILENAME_TEMPLATE.format(filename=".gitmodules")
+    )
+    diff_assessor = DiffAssessor(parsed_diff=parsed_diff)
+
+    assert (
+        diff_assessor.check_prevent_submodules()
+        == "Revision introduces a Git submodule into the repository."
+    ), "Check should prevent revisions from introducing submodules."


### PR DESCRIPTION
Add a check to the `DiffAssessor` API that prevents introduction of
the `.gitmodules` file, which tracks Git submodules in the repository.
