### PR TITLE
hg: convert errors from `hg id` to `HgException` (Bug 1908492)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -641,7 +641,10 @@ class HgRepo:
 
     def get_remote_head(self, source: str) -> bytes:
         # Obtain remote head. We assume there is only a single head.
-        cset = self.run_hg(["identify", source, "-r", "default", "--id"]).strip()
+        try:
+            cset = self.run_hg(["identify", source, "-r", "default", "--id"]).strip()
+        except hglib.error.CommandError as e:
+            raise HgException.from_hglib_error(e)
 
         assert len(cset) == 12, cset
         return cset


### PR DESCRIPTION
Since `hg id <repo_url>` hits the network to connect to hgmo,
it can fail due to internal server errors and other connectivity
issues. In this case, we want the landing job to be retried in
the same fashion as when failing to pull/push. Map the exception
raised by `run_hg` to an `HgException` so the failure will be
considered a retry in the landing worker.
