### PR TITLE
checks: add a push-wide check API and implement bug references check (Bug 1915671)

### DIFF
--- a/landoapi/api/try_push.py
+++ b/landoapi/api/try_push.py
@@ -19,8 +19,8 @@ from landoapi.hgexports import (
     BugReferencesCheck,
     GitPatchHelper,
     HgPatchHelper,
+    PatchCollectionAssessor,
     PatchHelper,
-    PushAssessor,
 )
 from landoapi.models.landing_job import (
     LandingJobStatus,
@@ -103,9 +103,9 @@ def parse_revisions_from_request(
         )
 
     try:
-        errors = PushAssessor(patch_helpers=patch_helpers, repo=repo).run_push_checks(
-            push_checks=[BugReferencesCheck]
-        )
+        errors = PatchCollectionAssessor(
+            patch_helpers=patch_helpers, repo=repo
+        ).run_patch_collection_checks(push_checks=[BugReferencesCheck])
     except ValueError as exc:
         raise ProblemException(
             400,

--- a/landoapi/api/try_push.py
+++ b/landoapi/api/try_push.py
@@ -16,6 +16,7 @@ from flask import (
 
 from landoapi import auth
 from landoapi.hgexports import (
+    BugReferencesCheck,
     GitPatchHelper,
     HgPatchHelper,
     PatchHelper,
@@ -102,7 +103,9 @@ def parse_revisions_from_request(
         )
 
     try:
-        errors = PushAssessor(patch_helpers=patch_helpers, repo=repo).run_push_checks()
+        errors = PushAssessor(patch_helpers=patch_helpers, repo=repo).run_push_checks(
+            push_checks=[BugReferencesCheck]
+        )
     except ValueError as exc:
         raise ProblemException(
             400,

--- a/landoapi/api/try_push.py
+++ b/landoapi/api/try_push.py
@@ -109,19 +109,17 @@ def parse_revisions_from_request(
     except ValueError as exc:
         raise ProblemException(
             400,
-            "Improper patch format.",
-            f"Patch does not match expected format `{patch_format.value}`: {str(exc)}",
+            "Error running checks on patch collection.",
+            f"Error running checks on patch collection: {str(exc)}",
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )
 
     if errors:
-        error_message = (
-            f"Patch does not match expected format `{patch_format.value}`: "
-            f"Patch failed checks: {' '.join(errors)}"
-        )
+        bulleted_errors = "\n  - ".join(errors)
+        error_message = f"Patch failed checks:\n\n  - {bulleted_errors}"
         raise ProblemException(
             400,
-            "Improper patch format.",
+            "Errors found in pre-submission patch checks.",
             error_message,
             type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400",
         )

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -69,7 +69,7 @@ def get_status_code_for_bug(bug_id: int) -> int:
 
 
 def uplift_get_bug(params: dict) -> dict:
-    """Retrieve bug information from the BMO REST API endpoint."""
+    """Retrieve bug information from the Lando Uplift Automation endpoint."""
     resp_get = api_request("GET", "lando/uplift", authenticated=True, params=params)
     resp_get.raise_for_status()
 
@@ -77,7 +77,7 @@ def uplift_get_bug(params: dict) -> dict:
 
 
 def uplift_update_bug(json: dict) -> requests.Response:
-    """Update a BMO bug."""
+    """Update a BMO bug via the Lando Uplift Automation endpoint."""
     if "ids" not in json or not json["ids"]:
         raise ValueError("Need bug values to be able to update!")
 

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -3,24 +3,41 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import requests
+from typing import Optional
 from flask import current_app
 
 
-def bmo_search_bug_endpoint() -> str:
-    """Returns the BMO bug search endpoint URL."""
-    return f"{current_app.config['BUGZILLA_URL']}/rest/bug"
+def bmo_default_headers() -> dict[str, str]:
+    """Returns a `dict` containing the default REST API headers."""
+    return {
+        "User-Agent": "Lando-API",
+        "X-Bugzilla-API-Key": current_app.config["BUGZILLA_API_KEY"],
+    }
+
+
+def bugzilla(
+    method: str, path: str, *args, headers: Optional[dict] = None, **kwargs
+) -> requests.Response:
+    """Send an HTTP `GET` request to BMO."""
+    url = f"{current_app.config['BUGZILLA_URL']}/rest/{path}"
+
+    common_headers = bmo_default_headers()
+    if headers:
+        common_headers.update(headers)
+
+    return requests.request(method, url, *args, headers=headers, **kwargs)
 
 
 def search_bugs(bug_ids: set[int]) -> set[int]:
     """Search for bugs with given IDs on BMO."""
-    bug_search_endpoint = bmo_search_bug_endpoint()
     params = {
         "id": ",".join(str(bug) for bug in sorted(bug_ids)),
         "include_fields": "id",
     }
 
-    resp = requests.get(
-        bug_search_endpoint,
+    resp = bugzilla(
+        "GET",
+        "bug",
         headers=bmo_default_headers(),
         params=params,
     )
@@ -32,10 +49,8 @@ def search_bugs(bug_ids: set[int]) -> set[int]:
 
 def get_status_code_for_bug(bug_id: int) -> int:
     """Given a bug ID, get the status code returned from BMO when attempting to access the bug."""
-    bug_endpoint = f"{bmo_search_bug_endpoint()}/{bug_id}"
-
     try:
-        resp = requests.get(bug_endpoint)
+        resp = bugzilla("GET", f"bug/{bug_id}")
         code = resp.status_code
     except requests.exceptions.HTTPError as exc:
         code = exc.response.status_code
@@ -43,27 +58,12 @@ def get_status_code_for_bug(bug_id: int) -> int:
     return code
 
 
-def bmo_uplift_endpoint() -> str:
-    """Returns the BMO uplift endpoint url for bugs."""
-    return f"{current_app.config['BUGZILLA_URL']}/rest/lando/uplift"
-
-
-def bmo_default_headers() -> dict[str, str]:
-    """Returns a `dict` containing the default REST API headers."""
-    return {
-        "User-Agent": "Lando-API",
-        "X-Bugzilla-API-Key": current_app.config["BUGZILLA_API_KEY"],
-    }
-
-
-def get_bug(params: dict) -> requests.Response:
+def get_bug(params: dict) -> dict:
     """Retrieve bug information from the BMO REST API endpoint."""
-    resp_get = requests.get(
-        bmo_uplift_endpoint(), headers=bmo_default_headers(), params=params
-    )
+    resp_get = bugzilla("GET", "lando/uplift", params=params)
     resp_get.raise_for_status()
 
-    return resp_get
+    return resp_get.json()
 
 
 def update_bug(json: dict) -> requests.Response:
@@ -71,9 +71,7 @@ def update_bug(json: dict) -> requests.Response:
     if "ids" not in json or not json["ids"]:
         raise ValueError("Need bug values to be able to update!")
 
-    resp_put = requests.put(
-        bmo_uplift_endpoint(), headers=bmo_default_headers(), json=json
-    )
+    resp_put = bugzilla("PUT", "lando/uplift", json=json)
     resp_put.raise_for_status()
 
     return resp_put

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -12,7 +12,7 @@ def api_request(
     method: str,
     path: str,
     *args,
-    authenticated: bool = False,
+    use_api_key: bool = False,
     headers: Optional[dict] = None,
     **kwargs,
 ) -> requests.Response:
@@ -34,7 +34,7 @@ def api_request(
     if headers:
         common_headers.update(headers)
 
-    if authenticated:
+    if use_api_key:
         common_headers["X-Bugzilla-API-Key"] = current_app.config["BUGZILLA_API_KEY"]
 
     return requests.request(method, url, *args, headers=headers, **kwargs)
@@ -71,7 +71,7 @@ def get_status_code_for_bug(bug_id: int) -> int:
 
 def uplift_get_bug(params: dict) -> dict:
     """Retrieve bug information from the Lando Uplift Automation endpoint."""
-    resp_get = api_request("GET", "lando/uplift", authenticated=True, params=params)
+    resp_get = api_request("GET", "lando/uplift", use_api_key=True, params=params)
     resp_get.raise_for_status()
 
     return resp_get.json()
@@ -82,7 +82,7 @@ def uplift_update_bug(json: dict) -> requests.Response:
     if "ids" not in json or not json["ids"]:
         raise ValueError("Need bug values to be able to update!")
 
-    resp_put = api_request("PUT", "lando/uplift", authenticated=True, json=json)
+    resp_put = api_request("PUT", "lando/uplift", use_api_key=True, json=json)
     resp_put.raise_for_status()
 
     return resp_put

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -2,9 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import requests
 from typing import Optional
 
+import requests
 from flask import current_app
 
 

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -58,7 +58,7 @@ def get_status_code_for_bug(bug_id: int) -> int:
     return code
 
 
-def get_bug(params: dict) -> dict:
+def uplift_get_bug(params: dict) -> dict:
     """Retrieve bug information from the BMO REST API endpoint."""
     resp_get = bugzilla("GET", "lando/uplift", params=params)
     resp_get.raise_for_status()
@@ -66,7 +66,7 @@ def get_bug(params: dict) -> dict:
     return resp_get.json()
 
 
-def update_bug(json: dict) -> requests.Response:
+def uplift_update_bug(json: dict) -> requests.Response:
     """Update a BMO bug."""
     if "ids" not in json or not json["ids"]:
         raise ValueError("Need bug values to be able to update!")

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -15,7 +15,16 @@ def api_request(
     headers: Optional[dict] = None,
     **kwargs,
 ) -> requests.Response:
-    """Send an HTTP `GET` request to BMO."""
+    """Send an HTTP request to BMO.
+
+    `method` is the HTTP method to use, ie `GET`, `POST`, etc.
+    `path` is the REST API endpoint to send the request to.
+    `authenticated` indicates if the privileged Lando Automation API key should be
+      used.
+    `headers` is the set of HTTP headers to pass to the request.
+
+    All other arguments in *args and **kwargs are passed through to `requests.request`.
+    """
     url = f"{current_app.config['BUGZILLA_URL']}/rest/{path}"
 
     common_headers = {

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -4,6 +4,7 @@
 
 import requests
 from typing import Optional
+
 from flask import current_app
 
 

--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -15,7 +15,7 @@ def api_request(
     headers: Optional[dict] = None,
     **kwargs,
 ) -> requests.Response:
-    """Send an HTTP request to BMO.
+    """Send an HTTP request to the BMO REST API.
 
     `method` is the HTTP method to use, ie `GET`, `POST`, etc.
     `path` is the REST API endpoint to send the request to.

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -636,7 +636,7 @@ class PushCheck:
         raise NotImplementedError()
 
     def next_diff(self, patch_helper: PatchHelper):
-        """Pass the next diff to be checked into the check and run."""
+        """Pass the next `PatchHelper` into the check."""
         raise NotImplementedError()
 
     def result(self) -> Optional[str]:

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -645,6 +645,11 @@ class BugReferencesCheck(PushCheck):
     skip_check: bool = False
 
     def next_diff(self, patch_helper: PatchHelper):
+        """Parse each diff for bug references information.
+
+        If `SKIP_BMO_CHECK` is detected in any commit message, set the
+        `skip_check` flag so the flag is disabled.
+        """
         commit_message = patch_helper.get_commit_description()
 
         # Skip the check if the `skip_check` flag is set.
@@ -655,6 +660,7 @@ class BugReferencesCheck(PushCheck):
         self.bug_ids |= set(parse_bugs(commit_message))
 
     def result(self) -> Optional[str]:
+        """Ensure all bug numbers detected in commit messages reference public bugs."""
         if self.skip_check or not self.bug_ids:
             return
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -642,9 +642,11 @@ class PatchCollectionCheck:
         raise NotImplementedError()
 
 
+BMO_SKIP_HINT = "Use `SKIP_BMO_CHECK` in your commit message to push anyway."
+
 BUG_REFERENCES_BMO_ERROR_TEMPLATE = (
     "Could not contact BMO to check for security bugs referenced in commit message. "
-    "Use `SKIP_BMO_CHECK` in your commit message to push anyway. Error: {error}."
+    f"{BMO_SKIP_HINT}. Error: {{error}}."
 )
 
 
@@ -695,18 +697,18 @@ class BugReferencesCheck(PatchCollectionCheck):
             return (
                 f"Your commit message references bug {bug_id}, which is currently private. To avoid "
                 "disclosing the nature of this bug publicly, please remove the affected bug ID "
-                "from the commit message."
+                f"from the commit message. {BMO_SKIP_HINT}"
             )
 
         if status_code == 404:
             return (
-                f"Your commit message references bug {bug_id}, which does not exist. Please check your "
-                "commit message and try again."
+                f"Your commit message references bug {bug_id}, which does not exist. "
+                f"Please check your commit message and try again. {BMO_SKIP_HINT}"
             )
 
         return (
-            f"While checking if bug {bug_id} in your commit message is a security bug, an error occurred "
-            "and the bug could not be verified."
+            f"While checking if bug {bug_id} in your commit message is a security bug, "
+            f"an error occurred and the bug could not be verified. {BMO_SKIP_HINT}"
         )
 
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -718,18 +718,13 @@ class PushAssessor:
     patch_helpers: Iterable[PatchHelper]
     repo: Repo
 
-    def run_push_checks(
-        self, push_checks: Optional[list[Type[PushCheck]]] = None
-    ) -> list[str]:
+    def run_push_checks(self, push_checks: list[Type[PushCheck]]) -> list[str]:
         """Execute the set of checks on the diffs, returning a list of issues.
 
         `push_checks` specifies the push-wide checks to run on the push, otherwise
         all checks will be run.
         """
         issues = []
-
-        if not push_checks:
-            push_checks = [BugReferencesCheck]
 
         checks = [
             check(repo=self.repo)

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -224,6 +224,9 @@ class HgPatchHelper(PatchHelper):
         finally:
             self.patch.seek(0)
 
+        if not self.headers:
+            raise ValueError("Failed to parse headers from patch.")
+
     def get_commit_description(self) -> str:
         """Returns the commit description."""
         commit_desc = []

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -628,12 +628,6 @@ class PushCheck:
     Then, `result` is called to receive the result of the check.
     """
 
-    repo: Repo
-
-    def relevant(self) -> bool:
-        """Return `True` if the check is relevant for the given repo."""
-        raise NotImplementedError()
-
     def next_diff(self, patch_helper: PatchHelper):
         """Pass the next `PatchHelper` into the check."""
         raise NotImplementedError()
@@ -649,12 +643,6 @@ class BugReferencesCheck(PushCheck):
 
     bug_ids: set[int] = field(default_factory=set)
     skip_check: bool = False
-
-    def relevant(self) -> bool:
-        if self.repo.tree == "try":
-            return True
-
-        return False
 
     def next_diff(self, patch_helper: PatchHelper):
         commit_message = patch_helper.get_commit_description()
@@ -726,11 +714,7 @@ class PushAssessor:
         """
         issues = []
 
-        checks = [
-            check(repo=self.repo)
-            for check in push_checks
-            if check(repo=self.repo).relevant()
-        ]
+        checks = [check() for check in push_checks]
 
         for patch_helper in self.patch_helpers:
             # Pass the patch information into the push-wide check.

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -637,6 +637,12 @@ class PushCheck:
         raise NotImplementedError()
 
 
+BUG_REFERENCES_BMO_ERROR_TEMPLATE = (
+    "Could not contact BMO to check for security bugs referenced in commit message. "
+    "Use `SKIP_BMO_CHECK` in your commit message to push anyway. Error: {error}."
+)
+
+
 @dataclass
 class BugReferencesCheck(PushCheck):
     """Prevent commit messages referencing non-public bugs from try."""
@@ -667,10 +673,7 @@ class BugReferencesCheck(PushCheck):
         try:
             found_bugs = search_bugs(self.bug_ids)
         except requests.exceptions.RequestException as exc:
-            return (
-                "Could not contact BMO to check for security bugs referenced in commit message. "
-                f"Use `SKIP_BMO_CHECK` in your commit message to push anyways. Error: {str(exc)}."
-            )
+            return BUG_REFERENCES_BMO_ERROR_TEMPLATE.format(error=str(exc))
 
         invalid_bugs = self.bug_ids - found_bugs
         if not invalid_bugs:
@@ -681,10 +684,7 @@ class BugReferencesCheck(PushCheck):
         try:
             status_code = get_status_code_for_bug(bug_id)
         except requests.exceptions.RequestException as exc:
-            return (
-                "Could not contact BMO to check for security bugs referenced in commit message. "
-                f"Use `SKIP_BMO_CHECK` in your commit message to push anyways. Error: {str(exc)}."
-            )
+            return BUG_REFERENCES_BMO_ERROR_TEMPLATE.format(error=str(exc))
 
         if status_code == 401:
             return (

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -620,7 +620,14 @@ class DiffAssessor:
 
 @dataclass
 class PushCheck:
-    """Provides an interface to implement push-wide checks."""
+    """Provides an interface to implement push-wide checks.
+
+    Each check implements a `relevant` function, which can be called to determine
+    if a check is relevant for a configurated repo. When looping over each patch in
+    the push, `next_diff` is called to give the current diff to the patch as a
+    `PatchHelper` subclass. Then, `result` is called to receive the result of the
+    check.
+    """
 
     repo: Repo
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -623,10 +623,9 @@ class PushCheck:
     """Provides an interface to implement push-wide checks.
 
     Each check implements a `relevant` function, which can be called to determine
-    if a check is relevant for a configurated repo. When looping over each patch in
-    the push, `next_diff` is called to give the current diff to the patch as a
-    `PatchHelper` subclass. Then, `result` is called to receive the result of the
-    check.
+    if a check is relevant. When looping over each patch in the push, `next_diff`
+    is called to give the current diff to the patch as a `PatchHelper` subclass.
+    Then, `result` is called to receive the result of the check.
     """
 
     repo: Repo

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -619,13 +619,12 @@ class DiffAssessor:
 
 
 @dataclass
-class PushCheck:
-    """Provides an interface to implement push-wide checks.
+class PatchCollectionCheck:
+    """Provides an interface to implement patch collection checks.
 
-    Each check implements a `relevant` function, which can be called to determine
-    if a check is relevant. When looping over each patch in the push, `next_diff`
-    is called to give the current diff to the patch as a `PatchHelper` subclass.
-    Then, `result` is called to receive the result of the check.
+    When looping over each patch in the collection, `next_diff` is called to give the
+    current diff to the patch as a `PatchHelper` subclass. Then, `result` is
+    called to receive the result of the check.
     """
 
     def next_diff(self, patch_helper: PatchHelper):
@@ -644,7 +643,7 @@ BUG_REFERENCES_BMO_ERROR_TEMPLATE = (
 
 
 @dataclass
-class BugReferencesCheck(PushCheck):
+class BugReferencesCheck(PatchCollectionCheck):
     """Prevent commit messages referencing non-public bugs from try."""
 
     bug_ids: set[int] = field(default_factory=set)
@@ -706,13 +705,15 @@ class BugReferencesCheck(PushCheck):
 
 
 @dataclass
-class PushAssessor:
+class PatchCollectionAssessor:
     """Assess pushes for landing issues."""
 
     patch_helpers: Iterable[PatchHelper]
     repo: Repo
 
-    def run_push_checks(self, push_checks: list[Type[PushCheck]]) -> list[str]:
+    def run_patch_collection_checks(
+        self, push_checks: list[Type[PatchCollectionCheck]]
+    ) -> list[str]:
         """Execute the set of checks on the diffs, returning a list of issues.
 
         `push_checks` specifies the push-wide checks to run on the push, otherwise

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -676,7 +676,7 @@ class BugReferencesCheck(PushCheck):
         if not invalid_bugs:
             return
 
-        # Check a single bug only.
+        # Check a single bug to determine which error to return.
         bug_id = invalid_bugs.pop()
         try:
             status_code = get_status_code_for_bug(bug_id)

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -633,7 +633,7 @@ class PushCheck:
         raise NotImplementedError()
 
     def result(self) -> Optional[str]:
-        """Return the result of the check."""
+        """Calcuate and return the result of the check."""
         raise NotImplementedError()
 
 

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -444,7 +444,7 @@ def update_bugs_for_uplift(
     }
 
     # Get information about the parsed bugs.
-    bugs = bmo.get_bug(params).json()["bugs"]
+    bugs = bmo.get_bug(params)["bugs"]
 
     # Get the major release number from `config/milestone.txt`.
     milestone = parse_milestone_version(milestone_file_contents)

--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -444,7 +444,7 @@ def update_bugs_for_uplift(
     }
 
     # Get information about the parsed bugs.
-    bugs = bmo.get_bug(params)["bugs"]
+    bugs = bmo.uplift_get_bug(params)["bugs"]
 
     # Get the major release number from `config/milestone.txt`.
     milestone = parse_milestone_version(milestone_file_contents)
@@ -461,7 +461,7 @@ def update_bugs_for_uplift(
         for i in range(1, UPLIFT_BUG_UPDATE_RETRIES + 1):
             # Update bug and account for potential errors.
             try:
-                bmo.update_bug(payload)
+                bmo.uplift_update_bug(payload)
 
                 break
             except requests.RequestException as e:

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -301,6 +301,7 @@ def test_patchhelper_no_header():
     patch = HgPatchHelper(
         io.StringIO(
             """
+# Date 1523427125 -28800
 WIP transplant and diff-start-line
 
 diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -13,7 +13,7 @@ from landoapi.hgexports import (
     DiffAssessor,
     GitPatchHelper,
     HgPatchHelper,
-    PushAssessor,
+    PatchCollectionAssessor,
     build_patch_for_revision,
 )
 from landoapi.repos import get_repos_for_env
@@ -913,9 +913,11 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
         # Mock out the status code check to simulate a public bug.
         mock_status_code.return_value = 200
 
-        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
+        assessor = PatchCollectionAssessor(repo=repo, patch_helpers=patch_helpers)
 
-        assert assessor.run_push_checks(push_checks=[BugReferencesCheck]) == []
+        assert (
+            assessor.run_patch_collection_checks(push_checks=[BugReferencesCheck]) == []
+        )
 
 
 def test_check_bug_references_private_bugs(mocked_repo_config):
@@ -947,8 +949,8 @@ Bug 999999: Fix issue with feature X
         # Mock out the status code check to simulate a private bug.
         mock_status_code.return_value = 401
 
-        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
-        issues = assessor.run_push_checks(push_checks=[BugReferencesCheck])
+        assessor = PatchCollectionAssessor(repo=repo, patch_helpers=patch_helpers)
+        issues = assessor.run_patch_collection_checks(push_checks=[BugReferencesCheck])
 
         assert (
             "Your commit message references bug 999999, which is currently private."
@@ -986,8 +988,8 @@ SKIP_BMO_CHECK
         # Mock out the status code check to simulate a private bug.
         mock_status_code.return_value = 401
 
-        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
-        issues = assessor.run_push_checks(push_checks=[BugReferencesCheck])
+        assessor = PatchCollectionAssessor(repo=repo, patch_helpers=patch_helpers)
+        issues = assessor.run_patch_collection_checks(push_checks=[BugReferencesCheck])
 
         assert (
             issues == []
@@ -1024,8 +1026,8 @@ Bug 123456: Fix issue with feature Y
 
         mock_status_code.side_effect = status_error
 
-        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
-        issues = assessor.run_push_checks(push_checks=[BugReferencesCheck])
+        assessor = PatchCollectionAssessor(repo=repo, patch_helpers=patch_helpers)
+        issues = assessor.run_patch_collection_checks(push_checks=[BugReferencesCheck])
 
         assert (
             issues

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -2,14 +2,18 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import io
+from unittest.mock import patch
 
 import pytest
+import requests
 import rs_parsepatch
 
 from landoapi.hgexports import (
+    BugReferencesCheck,
     DiffAssessor,
     GitPatchHelper,
     HgPatchHelper,
+    PushAssessor,
     build_patch_for_revision,
 )
 from landoapi.repos import get_repos_for_env
@@ -604,7 +608,7 @@ def test_check_wpt_sync_irrelevant_user(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="somefile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="sheehan@mozilla.com",
+        email="sheehan@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message=COMMIT_MESSAGE,
@@ -619,7 +623,7 @@ def test_check_wpt_sync_no_repo():
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="somefile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="wptsync@mozilla.com",
+        email="wptsync@mozilla.com",
         parsed_diff=parsed_diff,
         commit_message=COMMIT_MESSAGE,
     )
@@ -636,7 +640,7 @@ def test_check_wpt_sync_try(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="somefile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="wptsync@mozilla.com",
+        email="wptsync@mozilla.com",
         parsed_diff=parsed_diff,
         commit_message=COMMIT_MESSAGE,
         repo=try_repo,
@@ -652,7 +656,7 @@ def test_check_wpt_sync_non_central_repo(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="somefile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="wptsync@mozilla.com",
+        email="wptsync@mozilla.com",
         parsed_diff=parsed_diff,
         commit_message=COMMIT_MESSAGE,
         repo=invalid_repo,
@@ -670,7 +674,7 @@ def test_check_wpt_sync_invalid_paths(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="somefile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="wptsync@mozilla.com",
+        email="wptsync@mozilla.com",
         parsed_diff=parsed_diff,
         commit_message=COMMIT_MESSAGE,
         repo=valid_repo,
@@ -688,7 +692,7 @@ def test_check_wpt_sync_valid_paths(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="testing/web-platform/moz.build")
     )
     diff_assessor = DiffAssessor(
-        author="wptsync@mozilla.com",
+        email="wptsync@mozilla.com",
         parsed_diff=parsed_diff,
         commit_message=COMMIT_MESSAGE,
         repo=valid_repo,
@@ -706,7 +710,7 @@ def test_check_prevent_nspr_nss_missing_fields(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="security/nss/testfile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
     )
@@ -715,7 +719,7 @@ def test_check_prevent_nspr_nss_missing_fields(mocked_repo_config):
     ), "Missing commit message should result in passing check."
 
     diff_assessor = DiffAssessor(
-        author="wptsync@mozilla.com",
+        email="wptsync@mozilla.com",
         parsed_diff=parsed_diff,
         commit_message=COMMIT_MESSAGE,
     )
@@ -732,7 +736,7 @@ def test_check_prevent_nspr_nss_try_allowed(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="security/nss/testfile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message=COMMIT_MESSAGE,
@@ -750,7 +754,7 @@ def test_check_prevent_nspr_nss_nss(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="security/nss/testfile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message=COMMIT_MESSAGE,
@@ -761,7 +765,7 @@ def test_check_prevent_nspr_nss_nss(mocked_repo_config):
     ), "Check should disallow changes to NSS without proper commit message."
 
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message="bug 123: upgrade NSS UPGRADE_NSS_RELEASE",
@@ -779,7 +783,7 @@ def test_check_prevent_nspr_nss_nspr(mocked_repo_config):
         GIT_DIFF_FILENAME_TEMPLATE.format(filename="nsprpub/testfile.txt")
     )
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message=COMMIT_MESSAGE,
@@ -790,7 +794,7 @@ def test_check_prevent_nspr_nss_nspr(mocked_repo_config):
     ), "Check should disallow changes to NSPR without proper commit message."
 
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message="bug 123: upgrade NSS UPGRADE_NSPR_RELEASE",
@@ -810,7 +814,7 @@ def test_check_prevent_nspr_nss_combined(mocked_repo_config):
 
     parsed_diff = rs_parsepatch.get_diffs(combined_patch)
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message=COMMIT_MESSAGE,
@@ -821,7 +825,7 @@ def test_check_prevent_nspr_nss_combined(mocked_repo_config):
     ), "Check should disallow changes to both NSS and NSPR without proper commit message."
 
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message="bug 123: upgrade NSS UPGRADE_NSPR_RELEASE",
@@ -832,7 +836,7 @@ def test_check_prevent_nspr_nss_combined(mocked_repo_config):
     ), "Check should allow changes to NSPR with proper commit message."
 
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message="bug 123: upgrade NSS UPGRADE_NSS_RELEASE",
@@ -843,7 +847,7 @@ def test_check_prevent_nspr_nss_combined(mocked_repo_config):
     ), "Check should allow changes to NSPR with proper commit message."
 
     diff_assessor = DiffAssessor(
-        author="testuser@mozilla.com",
+        email="testuser@mozilla.com",
         parsed_diff=parsed_diff,
         repo=valid_repo,
         commit_message="bug 123: upgrade NSS UPGRADE_NSS_RELEASE UPGRADE_NSPR_RELEASE",
@@ -872,3 +876,159 @@ def test_check_prevent_submodules():
         diff_assessor.check_prevent_submodules()
         == "Revision introduces a Git submodule into the repository."
     ), "Check should prevent revisions from introducing submodules."
+
+
+def test_check_bug_references_public_bugs(mocked_repo_config):
+    supported_repos = get_repos_for_env("test")
+    repo = supported_repos["try"]
+
+    patch_helper = HgPatchHelper(
+        io.StringIO(
+            """
+# HG changeset patch
+# User byron jones <glob@mozilla.com>
+# Date 1523427125 -28800
+#      Wed Apr 11 14:12:05 2018 +0800
+# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
+# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
+bug 123: WIP transplant and diff-start-line
+
+diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
+--- a/autoland/autoland/transplant.py
++++ b/autoland/autoland/transplant.py
+@@ -318,24 +318,58 @@ class PatchTransplant(Transplant):
+# instead of passing the url to 'hg import' to make
+...
+""".strip()
+        )
+    )
+    patch_helpers = [patch_helper]
+
+    # Simulate contacting BMO returning a public bug state.
+    with patch("landoapi.hgexports.get_status_code_for_bug") as mock_status_code, patch(
+        "landoapi.hgexports.search_bugs"
+    ) as mock_bug_search:
+        mock_bug_search.side_effect = lambda bug_ids: bug_ids
+
+        # Mock out the status code check to simulate a public bug.
+        mock_status_code.return_value = 200
+
+        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
+
+        assert assessor.run_push_checks(push_checks=[BugReferencesCheck]) == []
+
+
+def test_check_bug_references_private_bugs(mocked_repo_config):
+    supported_repos = get_repos_for_env("test")
+    repo = supported_repos["try"]
+
+    # Simulate a patch that references a private bug.
+    patch_helper = HgPatchHelper(
+        io.StringIO(
+            """
+# HG changeset patch
+# User byron jones <glob@mozilla.com>
+# Date 1523427125 -28800
+# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
+# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
+Bug 999999: Fix issue with feature X
+""".strip()
+        )
+    )
+    patch_helpers = [patch_helper]
+
+    # Simulate Bugzilla (BMO) responding that the bug is private.
+    with patch("landoapi.hgexports.get_status_code_for_bug") as mock_status_code, patch(
+        "landoapi.hgexports.search_bugs"
+    ) as mock_bug_search:
+        # Mock out bug search to simulate our bug not being found.
+        mock_bug_search.return_value = set()
+
+        # Mock out the status code check to simulate a private bug.
+        mock_status_code.return_value = 401
+
+        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
+        issues = assessor.run_push_checks(push_checks=[BugReferencesCheck])
+
+        assert (
+            "Your commit message references bug 999999, which is currently private."
+            in issues[0]
+        )
+
+
+def test_check_bug_references_skip_check(mocked_repo_config):
+    supported_repos = get_repos_for_env("test")
+    repo = supported_repos["try"]
+
+    # Simulate a patch with SKIP_BMO_CHECK in the commit message.
+    patch_helper = HgPatchHelper(
+        io.StringIO(
+            """
+# HG changeset patch
+# User byron jones <glob@mozilla.com>
+# Date 1523427125 -28800
+# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
+# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
+Bug 999999: Fix issue with feature X
+SKIP_BMO_CHECK
+""".strip()
+        )
+    )
+    patch_helpers = [patch_helper]
+
+    # Simulate Bugzilla (BMO) responding that the bug is private.
+    with patch("landoapi.hgexports.get_status_code_for_bug") as mock_status_code, patch(
+        "landoapi.hgexports.search_bugs"
+    ) as mock_bug_search:
+        # Mock out bug search to simulate our bug not being found.
+        mock_bug_search.return_value = set()
+
+        # Mock out the status code check to simulate a private bug.
+        mock_status_code.return_value = 401
+
+        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
+        issues = assessor.run_push_checks(push_checks=[BugReferencesCheck])
+
+        assert (
+            issues == []
+        ), "Check should always pass when `SKIP_BMO_CHECK` is present."
+
+
+def test_check_bug_references_bmo_error(mocked_repo_config):
+    supported_repos = get_repos_for_env("test")
+    repo = supported_repos["try"]
+
+    # Simulate a patch that references a bug.
+    patch_helper = HgPatchHelper(
+        io.StringIO(
+            """
+# HG changeset patch
+# User byron jones <glob@mozilla.com>
+# Date 1523427125 -28800
+# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
+# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
+Bug 123456: Fix issue with feature Y
+""".strip()
+        )
+    )
+    patch_helpers = [patch_helper]
+
+    # Simulate an error occurring when trying to contact BMO.
+    with patch("landoapi.hgexports.get_status_code_for_bug") as mock_status_code, patch(
+        "landoapi.hgexports.search_bugs"
+    ) as mock_bug_search:
+        mock_bug_search.return_value = set()
+
+        def status_error(*args, **kwargs):
+            raise requests.exceptions.RequestException("BMO connection failed")
+
+        mock_status_code.side_effect = status_error
+
+        assessor = PushAssessor(repo=repo, patch_helpers=patch_helpers)
+        issues = assessor.run_push_checks(push_checks=[BugReferencesCheck])
+
+        assert (
+            issues
+            and "Could not contact BMO to check for security bugs referenced in commit message."
+            in issues[0]
+        )

--- a/tests/test_try.py
+++ b/tests/test_try.py
@@ -254,10 +254,10 @@ def test_symlink_diff_inspect(
         response.status_code == 400
     ), "Try push which fails diff checks should return 400."
 
-    assert response.json["title"] == "Improper patch format."
+    assert response.json["title"] == "Errors found in pre-submission patch checks."
     assert response.json["detail"] == (
-        "Patch does not match expected format `git-format-patch`: "
-        "Patch failed checks: Revision introduces symlinks in the files `blahfile_symlink`."
+        "Patch failed checks:\n\n"
+        "  - Revision introduces symlinks in the files `blahfile_symlink`."
     ), "Details message should indicate an introduced symlink."
 
 


### PR DESCRIPTION
Adds an API for push-wide checks and implements the bug references check
using it. The API defines a `PushCheck` interface which initializes the
check with a repo, defines a `relevant()` function which is called to
determine if the check should be run on the given repo, a `next_diff()`
function which accepts each diff parsed as a `PatchHelper`, and a
`result()` function which returns the error message for the check,
or `None` if the check passed.

The `BugReferencesCheck` is the first check to be implemented using this
new API. The check is only relevant on `try` repositories. Each diff is
passed via `next_diff`, and if `SKIP_BMO_CHECK` is found in the commit
message of any diff, a flag is set which indicates the check will be
skipped, otherwise the bug numbers found in the commit message are
stored. On `result()` the `skip_check` flag will cause an unconditional
pass, otherwise BMO is pinged to check the bug numbers in the commit
message are all referencing public bugs.

Since the `author` field was always assumed to be an email address, it was
renamed to the more accurate `email` name.