### PR TITLE
git-patch-helper: use `strip_git_version_info_lines` when empty commit is found (Bug 1921023)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -350,7 +350,10 @@ class GitPatchHelper(PatchHelper):
             # must be an empty commit. Discard the last two lines of the
             # constructed commit message which are Git version info and return
             # an empty diff.
-            commit_message = "\n".join(commit_message_lines[:-2])
+            commit_message_lines = GitPatchHelper.strip_git_version_info_lines(
+                commit_message_lines
+            )
+            commit_message = "\n".join(commit_message_lines)
             return commit_message, ""
 
         commit_message = "\n".join(commit_message_lines)

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -347,9 +347,8 @@ class GitPatchHelper(PatchHelper):
             commit_message_lines.append(line)
         else:
             # We never found the end of the commit message body, so this change
-            # must be an empty commit. Discard the last two lines of the
-            # constructed commit message which are Git version info and return
-            # an empty diff.
+            # must be an empty commit. Discard the Git version info from the commit
+            # message and return an empty diff.
             commit_message_lines = GitPatchHelper.strip_git_version_info_lines(
                 commit_message_lines
             )


### PR DESCRIPTION
Previously we had just removed the last two lines of output,
however if the patch has extra newlines this could fail and
cause the patch to be deformed. Use the helper function we
added to avoid issues with parsing the commit message.
