### PR TITLE
git-patch-helper: set charset to `utf-8` in email message parser (Bug 1893976)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -287,6 +287,7 @@ class GitPatchHelper(PatchHelper):
         self.message = email.message_from_string(
             self.patch.read(), policy=default_email_policy
         )
+        self.message.set_charset("utf-8")
         self.commit_message, self.diff = self.parse_email_body(
             self.message.get_content()
         )

--- a/tests/test_hgexports.py
+++ b/tests/test_hgexports.py
@@ -103,6 +103,61 @@ index f56ba1c..33391ea 100644
 
 """.lstrip()
 
+GIT_PATCH_UTF8 = """
+diff --git a/testing/web-platform/tests/html/dom/elements/global-attributes/dir-auto-dynamic-simple-textContent.html b/testing/web-platform/tests/html/dom/elements/global-attributes/dir-auto-dynamic-simple-textContent.html
+new file mode 100644
+--- /dev/null
++++ b/testing/web-platform/tests/html/dom/elements/global-attributes/dir-auto-dynamic-simple-textContent.html
+@@ -0,0 +1,31 @@
++<!DOCTYPE html>
++<html class="reftest-wait">
++<meta charset="utf-8">
++<title>Dynamic changes with textContent and dir=auto</title>
++<link rel="match" href="dir-auto-dynamic-simple-ref.html">
++<div>Test for elements with dir="auto" whose content changes between directional and neutral</div>
++<div dir="auto" id="from_ltr_to_ltr">abc</div>
++<div dir="auto" id="from_ltr_to_rtl">abc</div>
++<div dir="auto" id="from_ltr_to_neutral">abc</div>
++<div dir="auto" id="from_rtl_to_ltr">אבג</div>
++<div dir="auto" id="from_rtl_to_rtl">אבג</div>
++<div dir="auto" id="from_rtl_to_neutral">אבג</div>
++<div dir="auto" id="from_neutral_to_ltr">123</div>
++<div dir="auto" id="from_neutral_to_rtl">123</div>
++<div dir="auto" id="from_neutral_to_neutral">123</div>
++<script>
++function changeContent() {
++  var directionalTexts = {ltr:"xyz", rtl:"ابج", neutral:"456"};
++
++  for (var dirFrom in directionalTexts) {
++    for (var dirTo in directionalTexts) {
++      var element = document.getElementById("from_" + dirFrom +
++                                            "_to_" + dirTo);
++      element.textContent = directionalTexts[dirTo];
++    }
++  }
++  document.documentElement.removeAttribute("class");
++}
++
++document.addEventListener("TestRendered", changeContent);
++</script>
+""".strip()
+
+GIT_FORMATPATCH_UTF8 = f"""
+From 71ce7889eaa24616632a455636598d8f5c60b765 Mon Sep 17 00:00:00 2001
+From: Connor Sheehan <sheehan@mozilla.com>
+Date: Wed, 21 Feb 2024 10:20:49 +0000
+Subject: [PATCH] Bug 1874040 - Move 1103348-1.html to WPT, and expand it.
+ r=smaug
+
+---
+ .../dir-auto-dynamic-simple-textContent.html  | 31 ++++++++++++++++
+ 1 files changed, 31 insertions(+), 0 deletions(-)
+ create mode 100644 testing/web-platform/tests/html/dom/elements/global-attributes/dir-auto-dynamic-simple-textContent.html
+{GIT_PATCH_UTF8}
+--
+2.46.1
+""".strip()
+
 GIT_PATCH_ONLY_DIFF = """diff --git a/landoui/errorhandlers.py b/landoui/errorhandlers.py
 index f56ba1c..33391ea 100644
 --- a/landoui/errorhandlers.py
@@ -431,6 +486,14 @@ def test_git_formatpatch_helper_empty_commit():
         "unavailable at the moment and is not broken."
     ), "`commit_description()` should return full commit message."
     assert patch.get_diff() == "", "`get_diff()` should return an empty string."
+
+
+def test_git_formatpatch_helper_utf8():
+    helper = GitPatchHelper(io.StringIO(GIT_FORMATPATCH_UTF8))
+
+    assert (
+        helper.get_diff() == GIT_PATCH_UTF8
+    ), "`get_diff()` should return unescaped unicode and match the original patch."
 
 
 def test_strip_git_version_info_lines():


### PR DESCRIPTION
When parsing the Git patch sent through `git format-patch`, the
email parser returns escaped unicode. Explicitly set the charset
of the email to `utf-8` so the unescaped unicode string is returned.

Add a test which uses a real-life example of this issue, which fails
without specifying the charset but passes afterwards.
