### PR TITLE
autoformat: remove `eslint` from supported formatters list (Bug 1924891)

### DIFF
--- a/landoapi/hg.py
+++ b/landoapi/hg.py
@@ -428,7 +428,6 @@ class HgRepo:
         supported_formatters = [
             "black",
             "clang-format",
-            "eslint",
             "rustfmt",
         ]
 


### PR DESCRIPTION
`eslint` can make more than just formatting fixes, so we should disable it.
