### PR TITLE
bmo: use `common_headers` instead of `headers` in requests (Bug 1925420)

### DIFF
--- a/landoapi/bmo.py
+++ b/landoapi/bmo.py
@@ -37,7 +37,7 @@ def api_request(
     if use_api_key:
         common_headers["X-Bugzilla-API-Key"] = current_app.config["BUGZILLA_API_KEY"]
 
-    return requests.request(method, url, *args, headers=headers, **kwargs)
+    return requests.request(method, url, *args, headers=common_headers, **kwargs)
 
 
 def search_bugs(bug_ids: set[int]) -> set[int]:


### PR DESCRIPTION
`headers` includes headers passed to the callers, which we add to the
`common_headers` dict to include things like the UA string and
API key. When we create the actual request, we are instead passing
the `headers` object and ignoring our common headers. Pass
`common_headers` to `requests.request` instead.
