### PR TITLE
commit_message: change `parse_bugs` to use `BUG_CONSERVATIVE_RE` (Bug 1926431)

### DIFF
--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -12,7 +12,7 @@ REVISION_URL_TEMPLATE = "Differential Revision: {url}"
 
 # Like BUG_RE except it doesn't flag sequences of numbers, only positive
 # "bug" syntax like "bug X" or "b=".
-BUG_CONSERVATIVE_RE = re.compile(r"""((?:bug|b=)(?:\s*)(\d+)(?=\b))""", re.I | re.X)
+BUG_CONSERVATIVE_RE = re.compile(r"""(\b(?:bug|b=)\b(?:\s*)(\d+)(?=\b))""", re.I | re.X)
 
 SPECIFIER = r"\b(?:r|a|sr|rs|ui-r)[=?]"
 SPECIFIER_RE = re.compile(SPECIFIER)

--- a/landoapi/commit_message.py
+++ b/landoapi/commit_message.py
@@ -10,26 +10,6 @@ from typing import (
 
 REVISION_URL_TEMPLATE = "Differential Revision: {url}"
 
-# These regular expressions are not very robust. Specifically, they fail to
-# handle lists well.
-BUG_RE = re.compile(
-    r"""
-    # bug followed by any sequence of numbers, or
-    # a standalone sequence of numbers
-    (
-        (?:
-            bug |
-            b= |
-            # a sequence of 5+ numbers preceded by whitespace
-            (?=\b\#?\d{5,}) |
-            # numbers at the very beginning
-            ^(?=\d)
-        )
-        (?:\s*\#?)(\d+)(?=\b)
-    )""",
-    re.I | re.X,
-)
-
 # Like BUG_RE except it doesn't flag sequences of numbers, only positive
 # "bug" syntax like "bug X" or "b=".
 BUG_CONSERVATIVE_RE = re.compile(r"""((?:bug|b=)(?:\s*)(\d+)(?=\b))""", re.I | re.X)
@@ -109,25 +89,6 @@ BACKOUT_MULTI_ONELINE_RE = re.compile(
 )
 RE_SOURCE_REPO = re.compile(r"^Source-Repo: (https?:\/\/.*)$", re.MULTILINE)
 RE_SOURCE_REVISION = re.compile(r"^Source-Revision: (.*)$", re.MULTILINE)
-# Like BUG_RE except it doesn't flag sequences of numbers, only positive
-# "bug" syntax like "bug X" or "b=".
-BUG_CONSERVATIVE_RE = re.compile(r"""(\b(?:bug|b=)\b(?:\s*)(\d+)(?=\b))""", re.I | re.X)
-BUG_RE = re.compile(
-    r"""# bug followed by any sequence of numbers, or
-        # a standalone sequence of numbers
-         (
-           (?:
-             bug |
-             b= |
-             # a sequence of 5+ numbers preceded by whitespace
-             (?=\b\#?\d{5,}) |
-             # numbers at the very beginning
-             ^(?=\d)
-           )
-           (?:\s*\#?)(\d+)(?=\b)
-         )""",
-    re.I | re.X,
-)
 
 
 def is_backout(commit_desc: str) -> bool:
@@ -256,7 +217,7 @@ def format_commit_message(
 
 def parse_bugs(message: str) -> list[int]:
     """Parse `commit_message` and return a list of `int` bug numbers."""
-    bugs_with_duplicates = [int(m[1]) for m in BUG_RE.findall(message)]
+    bugs_with_duplicates = [int(m[1]) for m in BUG_CONSERVATIVE_RE.findall(message)]
     bugs_seen = set()
     bugs_seen_add = bugs_seen.add
     bugs = [x for x in bugs_with_duplicates if not (x in bugs_seen or bugs_seen_add(x))]

--- a/tests/test_commit_message.py
+++ b/tests/test_commit_message.py
@@ -6,6 +6,7 @@ import pytest
 from landoapi.commit_message import (
     bug_list_to_commit_string,
     format_commit_message,
+    parse_bugs,
     split_title_and_summary,
 )
 
@@ -218,3 +219,19 @@ def test_bug_list_to_commit_string():
     assert (
         bug_list_to_commit_string(["123", "123"]) == "Bug 123"
     ), "Multiple bugs should be deduplicated."
+
+
+BUG_COMMIT_MESSAGE = """
+Bug 1803416 - Part 1: WindowsAppSDK toolchain. r?glandium
+
+This follows an approach suggested
+[here](https://github.com/microsoft/WindowsAppSDK/discussions/1891#discussioncomment-2043601).
+
+Differential Revision: https://phabricator.services.mozilla.com/D223371
+""".lstrip()
+
+
+def test_parse_bugs():
+    assert parse_bugs(BUG_COMMIT_MESSAGE) == [
+        1803416
+    ], "`parse_bugs` should only return the appropriate bug numbers."


### PR DESCRIPTION
Change `parse_bugs` to use `BUG_CONSERVATIVE_RE` to avoid incorrect parsing
of bug numbers during the `BugReferencesCheck`. Other code paths use the
`parse_bugs` function as well, but their tests pass after this change, so
we fully remove `BUG_RE` since it is no longer used.

Also remove the accidental double-definition of `BUG_RE` and `BUG_CONSERVATIVE_RE`
from `commit_message.py`.
