### PR TITLE
mocks: respect `limit` parameter in mock Conduit API endpoints (Bug 1927013)

### DIFF
--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -836,6 +836,9 @@ class PhabricatorDouble:
 
             items = [i for i in items if i["slug"] in constraints["slugs"]]
 
+        if limit:
+            items = items[:limit]
+
         return {
             "data": [to_response(i) for i in items],
             "maps": {"slugMap": {}},
@@ -897,6 +900,9 @@ class PhabricatorDouble:
             items = [
                 i for i in items if i["revisionPHID"] in constraints["revisionPHIDs"]
             ]
+
+        if limit:
+            items = items[:limit]
 
         return {
             "data": [to_response(i) for i in items],
@@ -972,6 +978,9 @@ class PhabricatorDouble:
 
         if destinationPHIDs:
             items = [i for i in items if i["destinationPHID"] in destinationPHIDs]
+
+        if limit:
+            items = items[:limit]
 
         return {
             "data": [to_response(i) for i in items],
@@ -1094,6 +1103,9 @@ class PhabricatorDouble:
                 )
 
             items = [i for i in items if i["status"].value in status_set]
+
+        if limit:
+            items = items[:limit]
 
         return {
             "data": [to_response(i) for i in items],
@@ -1336,6 +1348,9 @@ class PhabricatorDouble:
         if phids:
             items = [i for i in items if i["phid"] in phids]
 
+        if limit:
+            items = items[:limit]
+
         return [to_response(i) for i in items]
 
     @conduit_method("diffusion.repository.search")
@@ -1390,6 +1405,9 @@ class PhabricatorDouble:
 
         if "shortNames" in constraints:
             items = [i for i in items if i["shortName"] in constraints["shortNames"]]
+
+        if limit:
+            items = items[:limit]
 
         return {
             "data": [to_response(i) for i in items],
@@ -1667,6 +1685,9 @@ class PhabricatorDouble:
         if "nameLike" in constraints:
             items = [i for i in items if constraints["nameLike"] in i["userName"]]
 
+        if limit:
+            items = items[:limit]
+
         return {
             "data": [to_response(i) for i in items],
             "maps": {},
@@ -1719,6 +1740,9 @@ class PhabricatorDouble:
 
         if ids:
             items = [i for i in items if i["id"] in ids]
+
+        if limit:
+            items = items[:limit]
 
         return [to_response(i) for i in items]
 


### PR DESCRIPTION
The `PhabricatorDouble` mock API calls take the `limit` parameter,
but do not actually limit the number of entries in the response data.
Add a check if `limit` is set and slice the `items `list at that index.
