### PR TITLE
patch-helper: account for non-Git formatted author headers (Bug 1932215)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -103,8 +103,16 @@ def parse_git_author_information(user_header: str) -> tuple[str, str]:
     """Parse user's name and email address from a Git style author header.
 
     Converts a header like 'User Name <user@example.com>' to its separate parts.
+
+    If the parser could not split out the email from the user header,
+    assume it is improperly formatted and return the entire header
+    as the username instead.
     """
     name, email = parseaddr(user_header)
+
+    if not all({name, email}):
+        return user_header, ""
+
     return name, email
 
 

--- a/tests/test_try.py
+++ b/tests/test_try.py
@@ -66,11 +66,18 @@ def test_get_timestamp_from_date():
     ), "Timestamp from `git format-patch` should properly convert to `str`."
 
 
-def test_parse_git_author_information():
+def test_parse_git_author_information_well_formed():
     assert parse_git_author_information("User Name <user@example.com>") == (
         "User Name",
         "user@example.com",
     ), "Name and email information should be parsed into separate strings."
+
+
+def test_parse_git_author_information_no_email():
+    assert parse_git_author_information("ffxbld") == (
+        "ffxbld",
+        "",
+    ), "Name without email address should return the username and empty email."
 
 
 def test_try_api_requires_data(db, client, auth0_mock, mocked_repo_config):


### PR DESCRIPTION
`parse_git_author_information` is using `email.utils.parseaddr` to
parse the authorship information from Git and Mercurial patches.
In Mercurial, the standard Git format is not required, so users can
use values like `ffxbld` as their author header. When the parser
encounters fields such as this, the improperly formatted name
is returned as the email.

Update `parse_git_author_information` to return the raw header
as the username when the email is parsed as empty.
