### PR TITLE
checks: refactor `DiffAssessor` check to more closely resemble `PatchCollectionCheck` (Bug 1932507)

### DIFF
--- a/landoapi/api/try_push.py
+++ b/landoapi/api/try_push.py
@@ -21,6 +21,7 @@ from landoapi.hgexports import (
     HgPatchHelper,
     PatchCollectionAssessor,
     PatchHelper,
+    PreventSymlinksCheck,
 )
 from landoapi.models.landing_job import (
     LandingJobStatus,
@@ -104,8 +105,11 @@ def parse_revisions_from_request(
 
     try:
         errors = PatchCollectionAssessor(
-            patch_helpers=patch_helpers, repo=repo
-        ).run_patch_collection_checks(push_checks=[BugReferencesCheck])
+            patch_helpers=patch_helpers,
+        ).run_patch_collection_checks(
+            patch_collection_checks=[BugReferencesCheck],
+            patch_checks=[PreventSymlinksCheck],
+        )
     except ValueError as exc:
         raise ProblemException(
             400,

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -813,8 +813,9 @@ class PatchCollectionAssessor:
     ) -> list[str]:
         """Execute the set of checks on the diffs, returning a list of issues.
 
-        `push_checks` specifies the push-wide checks to run on the push, otherwise
-        all checks will be run.
+        `patch_collection_checks` specifies the collection-wide checks to run on the
+        `patch_helpers`. `patch_checks` specifies the checks to run on individual
+        patches.
         """
         issues = []
 

--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -8,6 +8,7 @@ import email
 import io
 import math
 import re
+from abc import abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from email.policy import (
@@ -449,13 +450,13 @@ class PatchCheck:
     email: Optional[str] = None
     commit_message: Optional[str] = None
 
+    @abstractmethod
     def next_diff(self, diff: dict):
         """Pass the next `rs_parsepatch` diff `dict` into the check."""
-        raise NotImplementedError()
 
+    @abstractmethod
     def result(self) -> Optional[str]:
         """Calcuate and return the result of the check."""
-        raise NotImplementedError()
 
 
 @dataclass
@@ -642,13 +643,13 @@ class PatchCollectionCheck:
     called to receive the result of the check.
     """
 
+    @abstractmethod
     def next_diff(self, patch_helper: PatchHelper):
         """Pass the next `PatchHelper` into the check."""
-        raise NotImplementedError()
 
+    @abstractmethod
     def result(self) -> Optional[str]:
         """Calcuate and return the result of the check."""
-        raise NotImplementedError()
 
 
 @dataclass

--- a/landoapi/transplants.py
+++ b/landoapi/transplants.py
@@ -22,7 +22,10 @@ from flask import current_app
 
 from landoapi.auth import A0User
 from landoapi.cache import DEFAULT_CACHE_KEY_TIMEOUT_SECONDS, cache
-from landoapi.hgexports import DiffAssessor
+from landoapi.hgexports import (
+    PreventSymlinksCheck,
+    TryTaskConfigCheck,
+)
 from landoapi.models.landing_job import LandingJob, LandingJobStatus
 from landoapi.models.revisions import DiffWarning, DiffWarningStatus
 from landoapi.phabricator import (
@@ -878,7 +881,11 @@ def blocker_prevent_symlinks(
     diff_id = PhabricatorClient.expect(diff, "id")
     parsed_diff = stack_state.parsed_diffs[diff_id]
 
-    return DiffAssessor(parsed_diff=parsed_diff).check_prevent_symlinks()
+    symlink_check = PreventSymlinksCheck()
+    for diff in parsed_diff:
+        symlink_check.next_diff(diff)
+
+    return symlink_check.result()
 
 
 def blocker_try_task_config(
@@ -888,11 +895,11 @@ def blocker_try_task_config(
     diff_id = PhabricatorClient.expect(diff, "id")
     parsed_diff = stack_state.parsed_diffs[diff_id]
 
-    local_repo = stack_state.get_repo_for_revision(revision)
+    try_task_config_check = TryTaskConfigCheck()
+    for diff in parsed_diff:
+        try_task_config_check.next_diff(diff)
 
-    return DiffAssessor(
-        parsed_diff=parsed_diff, repo=local_repo
-    ).check_try_task_config()
+    return try_task_config_check.result()
 
 
 STACK_BLOCKER_CHECKS = [


### PR DESCRIPTION
This commit refactors the `DiffAssessor` API to more closely
match the `PatchCollectionCheck` API. A `PatchCheck` abstract
class is introduced which has a similar interface as the
`PatchCollectionCheck`, where each check can store state
as each part of the patch is iterated over using `next_diff`,
and `result()` is called to determine the final result of
the check. Each check in the `DiffAssessor` class is moved
to a class which subclasses `PatchCheck`.

To make the patch checks more closely resemble the patch
collection checks, each check to be run is passed as an
argument to `run_patch_collection_checks`, which allows
us to run the relevant checks based on the code path
or known relevant repository instead of unconditionally
running all checks. As a result, all logic around inspecting
the repo and determining if a check is relevant is removed
from the checks, simplifying the APIs.
