### PR TITLE
uplift: skip Bugzilla updates for landings without bugs (Bug 1934003)

### DIFF
--- a/landoapi/uplift.py
+++ b/landoapi/uplift.py
@@ -436,9 +436,6 @@ def update_bugs_for_uplift(
     bug_ids: list[str],
 ):
     """Update Bugzilla bugs for uplift."""
-    if not bug_ids:
-        raise ValueError("No bugs found in uplift landing.")
-
     params = {
         "id": ",".join(bug_ids),
     }

--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -443,7 +443,7 @@ class LandingWorker(Worker):
             logger.info(f"{mots_path} not found, skipping setting reviewer data.")
 
         # Extra steps for post-uplift landings.
-        if repo.approval_required:
+        if repo.approval_required and bug_ids:
             try:
                 # If we just landed an uplift, update the relevant bugs as appropriate.
                 update_bugs_for_uplift(


### PR DESCRIPTION
Currently when an uplift without a bug number hits the
Bugzilla update code path, an exception is thrown which
is turned into a failure email indicating Bugzilla could
not be updated. This commit changes the behaviour to
avoid trying to update Bugzilla if no bug numbers are
detected.
