### PR TITLE
landing-worker: add a try/except block around `job.set_landed_reviewers` calls (Bug 1936373)

### DIFF
--- a/landoapi/workers/landing_worker.py
+++ b/landoapi/workers/landing_worker.py
@@ -437,8 +437,12 @@ class LandingWorker(Worker):
         mots_path = Path(hgrepo.path) / "mots.yaml"
         if mots_path.exists():
             logger.info(f"{mots_path} found, setting reviewer data.")
-            job.set_landed_reviewers(mots_path)
-            db.session.commit()
+            try:
+                job.set_landed_reviewers(mots_path)
+                db.session.commit()
+            except Exception as exc:
+                # Catch a wide exception here to work around bug 1936373.
+                logging.info(f"could not set reviewer data, continuing: {str(exc)}")
         else:
             logger.info(f"{mots_path} not found, skipping setting reviewer data.")
 


### PR DESCRIPTION
Catch any exceptions thrown while setting reviewers from `mots.yaml`, so
they do not take down the landing worker and cause lag in the queue.
