### PR TITLE
hgexports: fix CRLF handling in GitPatchHelper (bug 1944462)

### DIFF
--- a/landoapi/hgexports.py
+++ b/landoapi/hgexports.py
@@ -349,15 +349,13 @@ class GitPatchHelper(PatchHelper):
             raise ValueError("No valid subject header for commit message.")
 
         # Start the commit message from the stripped subject line.
-        commit_message_lines = [
-            subject_header.removeprefix("[PATCH] ").removesuffix("\n")
-        ]
+        commit_message_lines = [subject_header.removeprefix("[PATCH] ").rstrip("\r\n")]
 
         # Create an iterator for the lines of the patch.
-        line_iterator = iter(content.splitlines())
+        line_iterator = iter(content.splitlines(keepends=True))
 
         # Add each line to the commit message until we hit `---`.
-        for i, line in enumerate(line_iterator):
+        for i, line in enumerate(line.rstrip("\r\n") for line in line_iterator):
             if line == "---":
                 break
 
@@ -394,7 +392,7 @@ class GitPatchHelper(PatchHelper):
             list(line_iterator)
         )
         diff_lines += remaining_lines
-        diff = "\n".join(diff_lines)
+        diff = "".join(diff_lines)
 
         return commit_message, diff
 

--- a/tests/test_try.py
+++ b/tests/test_try.py
@@ -22,7 +22,7 @@ diff --git a/test.txt b/test.txt
 @@ -1,1 +1,2 @@
  TEST
 +adding another line
-""".strip()
+""".lstrip()
 
 PATCH_WITHOUT_STARTLINE = rb"""
 # HG changeset patch
@@ -36,7 +36,7 @@ diff --git a/test.txt b/test.txt
 @@ -1,1 +1,2 @@
  TEST
 +adding another line
-""".strip()
+""".lstrip()
 
 GIT_PATCH = rb"""From 0f5a3c99e12c1e9b0e81bed245fe537961f89e57 Mon Sep 17 00:00:00 2001
 From: Connor Sheehan <sheehan@mozilla.com>
@@ -56,7 +56,7 @@ diff --git a/test.txt b/test.txt
 +adding another line
 --
 2.31.1
-""".strip()
+"""
 
 
 def test_get_timestamp_from_date():
@@ -408,7 +408,7 @@ def test_try_api_success_hgexport(
         b"+++ b/test.txt\n"
         b"@@ -1,1 +1,2 @@\n"
         b" TEST\n"
-        b"+adding another line"
+        b"+adding another line\n"
     ), "Patch diff should be parsed from patch body."
 
 
@@ -499,5 +499,5 @@ def test_try_api_success_gitformatpatch(
         b"+++ b/test.txt\n"
         b"@@ -1,1 +1,2 @@\n"
         b" TEST\n"
-        b"+adding another line"
+        b"+adding another line\n"
     ), "Patch diff should be parsed from patch body."


### PR DESCRIPTION
HgPatchHelper doesn't have this problem because it uses io.StringIO,
which yields the line endings.

Some tests need to be accommodated to the fact that the last line of a
diff now does contain newlines, which was accidentally not the case
before, and while doing that, adjust a little more test strings to be
more fitting with the reality that a patch will not terminate without
a newline at the end.