### PR TITLE
api: Allow fetching landed commit_id of a landing job (bug 1954116)

### DIFF
--- a/landoapi/api/landing_jobs.py
+++ b/landoapi/api/landing_jobs.py
@@ -13,6 +13,33 @@ from landoapi.storage import db
 logger = logging.getLogger(__name__)
 
 
+def get(landing_job_id: str):
+    """Return status about a landing job
+
+    Args:
+        landing_job_id (str): The unique ID of the LandingJob object.
+
+    Raises:
+        ProblemException: If a LandingJob object corresponding to the landing_job_id
+            is not found.
+    """
+    landing_job = LandingJob.query.get(landing_job_id)
+
+    if not landing_job:
+        raise ProblemException(
+            404,
+            "Landing job not found",
+            f"A landing job with ID {landing_job_id} was not found.",
+            type="https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404",
+        )
+
+    return {
+        "id": landing_job.id,
+        "status": landing_job.status.value,
+        "commit_id": landing_job.landed_commit_id,
+    }
+
+
 @auth.require_auth0(scopes=("lando", "profile", "email"), userinfo=True)
 def put(landing_job_id: str, data: dict):
     """Update a landing job.

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -197,6 +197,46 @@ paths:
           schema:
             type: object
   /landing_jobs/{landing_job_id}:
+    get:
+      operationId: landoapi.api.landing_jobs.get
+      description: Gets landing job status
+      parameters:
+        - name: landing_job_id
+          in: path
+          type: string
+          required: true
+      responses:
+        200:
+          description: OK
+          schema:
+            type: object
+            properties:
+              id:
+                type: integer
+                description: Landing Job id
+              status:
+                type: string
+                description: Current job status
+                enum:
+                  - SUBMITTED
+                  - IN_PROGRESS
+                  - DEFERRED
+                  - FAILED
+                  - LANDED
+                  - CANCELLED
+              commit_id:
+                type: string
+                description: Commit identifier (such as hg hash)
+        404:
+          description: Landing job does not exist
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
+        default:
+          description: Unexpected error
+          schema:
+            allOf:
+              - $ref: '#/definitions/Error'
     put:
       operationId: landoapi.api.landing_jobs.put
       description: Updates a request to land (i.e. a landing job)


### PR DESCRIPTION
When tools push to try, they only get the landing job id in return, while they often want the commit_id that TreeHerder uses. If the job isn't landed yet, a simple status is returned instead. Landed commit_id or job status isn't sensitive so an auth check isn't required.