### PR TITLE
phabricator: use POST method to be HTTP spec-compliant (Bug 1952541)

### DIFF
--- a/landoapi/phabricator.py
+++ b/landoapi/phabricator.py
@@ -207,7 +207,7 @@ class PhabricatorClient:
         logger.debug("call to conduit", extra=extra_data)
 
         try:
-            response = self.session.get(self.api_url + method, data=data).json()
+            response = self.session.post(self.api_url + method, data=data).json()
         except requests.RequestException as exc:
             raise PhabricatorCommunicationException(
                 "An error occurred when communicating with Phabricator"

--- a/tests/test_dockerflow.py
+++ b/tests/test_dockerflow.py
@@ -37,7 +37,7 @@ def test_heartbeat_returns_http_502_if_phabricator_ping_returns_error(
         "error_info": "BOOM",
     }
 
-    request_mocker.get(phab_url("conduit.ping"), status_code=500, json=error_json)
+    request_mocker.post(phab_url("conduit.ping"), status_code=500, json=error_json)
     response = client.get("/__heartbeat__")
 
     assert request_mocker.called

--- a/tests/test_phabricator_client.py
+++ b/tests/test_phabricator_client.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.usefixtures("docker_env_vars")
 def test_ping_success(get_phab_client):
     phab = get_phab_client(api_key="api-key")
     with requests_mock.mock() as m:
-        m.get(
+        m.post(
             phab_url("conduit.ping"),
             status_code=200,
             json={"result": [], "error_code": None, "error_info": None},
@@ -32,7 +32,7 @@ def test_raise_exception_if_ping_encounters_connection_error(get_phab_client):
     with requests_mock.mock() as m:
         # Test with the generic ConnectionError, which is a superclass for
         # other connection error types.
-        m.get(phab_url("conduit.ping"), exc=requests.ConnectionError)
+        m.post(phab_url("conduit.ping"), exc=requests.ConnectionError)
 
         with pytest.raises(PhabricatorAPIException):
             phab.call_conduit("conduit.ping")
@@ -44,7 +44,7 @@ def test_raise_exception_if_api_ping_times_out(get_phab_client):
     with requests_mock.mock() as m:
         # Test with the generic Timeout exception, which all other timeout
         # exceptions derive from.
-        m.get(phab_url("conduit.ping"), exc=requests.Timeout)
+        m.post(phab_url("conduit.ping"), exc=requests.Timeout)
 
         with pytest.raises(PhabricatorAPIException):
             phab.call_conduit("conduit.ping")
@@ -62,7 +62,7 @@ def test_raise_exception_if_api_returns_error_json_response(get_phab_client):
     with requests_mock.mock() as m:
         # Test with the generic Timeout exception, which all other timeout
         # exceptions derive from.
-        m.get(phab_url("conduit.ping"), status_code=500, json=error_json)
+        m.post(phab_url("conduit.ping"), status_code=500, json=error_json)
 
         with pytest.raises(PhabricatorAPIException):
             phab.call_conduit("conduit.ping")
@@ -81,7 +81,7 @@ def test_phabricator_exception(get_phab_client):
     }
 
     with requests_mock.mock() as m:
-        m.get(phab_url("differential.query"), status_code=200, json=error)
+        m.post(phab_url("differential.query"), status_code=200, json=error)
         with pytest.raises(PhabricatorAPIException) as e_info:
             phab.call_conduit("differential.query", ids=["1"])[0]
         assert e_info.value.error_code == error["error_code"]


### PR DESCRIPTION
Some CDNs and WAFs block HTTP GET requests with bodies as security
measure. This patch changes the HTTP method to POST, which is spec
compliant. https://www.rfc-editor.org/rfc/rfc9110#name-get
