### PR TITLE
cinnabar: check if `git2hg` returns the null SHA and defer jobs (Bug 1964576)

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -33,6 +33,11 @@ RUN addgroup --gid 10001 app \
         --gecos "app,,," \
         app
 
+# Install `git-cinnabar`.
+COPY install_git-cinnabar.sh .
+RUN ./install_git-cinnabar.sh \
+    && mv git-cinnabar git-remote-hg /usr/bin/
+
 # TODO: there are some packages here that we do not need.
 COPY requirements.txt /python_requirements.txt
 RUN pip install pip --upgrade


### PR DESCRIPTION
When converting the passed Git SHA to a Mercurial SHA, Lando-API
currently does nothing to assert the returned SHA is valid.
Add a check that the returned SHA is not the null SHA, and
raise a custom exception if it is. If a landing job hits this
exception, consider it a temporary failure and defer the job
until later.

In testing this patch I realized we do not install `git-cinnabar`
in the `Dockerfile-dev` file, so add that now to allow `git2hg`
to actually fail in the test.
