### PR TITLE
Add ability to specify try repo

### DIFF
--- a/landoapi/api/try_push.py
+++ b/landoapi/api/try_push.py
@@ -153,7 +153,7 @@ def post_patches(data: dict):
     patch_format = PatchFormat(data["patch_format"])
 
     environment_repos = get_repos_for_env(current_app.config.get("ENVIRONMENT"))
-    try_repo = environment_repos.get("try")
+    try_repo = environment_repos.get(data.get("try_repo"), "try")
     if not try_repo:
         raise ProblemException(
             500,

--- a/landoapi/repos.py
+++ b/landoapi/repos.py
@@ -288,6 +288,17 @@ REPO_CONFIG = {
             force_push=True,
             native_git_source="https://github.com/mozilla-firefox/firefox",
         ),
+        "try-comm-central": Repo(
+            tree="try-comm-central",
+            url="https://hg.mozilla.org/try-comm-central",
+            push_path="ssh://hg.mozilla.org/try-comm-central",
+            pull_path="https://hg.mozilla.org/comm-unified",
+            access_group=SCM_LEVEL_1,
+            short_name="try-cc",
+            is_phabricator_repo=False,
+            force_push=True,
+            native_git_source="https://github.com/thunderbird/thunderbird-desktop",
+        ),
     },
 }
 

--- a/landoapi/spec/swagger.yml
+++ b/landoapi/spec/swagger.yml
@@ -431,6 +431,11 @@ paths:
                 enum: ["git", "hg"]
                 description : |
                   The VCS that the `base_commit` hash is based on. Default is `hg`.
+              try_repo:
+                type: string
+                enum: ["try", "try-comm-central"]
+                description : |
+                  The try repo to submit the patch to.
       responses:
         201:
           description: Push was submitted successfully.


### PR DESCRIPTION
With Thunderbird's transition over to git, we'd like to add support for using `mach try` on Thunderbird patches.

https://phabricator.services.mozilla.com/D278840